### PR TITLE
[feat] 메인홈 약속 조회 관련 API 구현 

### DIFF
--- a/src/main/java/org/kkumulkkum/server/controller/PromiseController.java
+++ b/src/main/java/org/kkumulkkum/server/controller/PromiseController.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.kkumulkkum.server.annotation.IsMember;
 import org.kkumulkkum.server.annotation.UserId;
 import org.kkumulkkum.server.dto.promise.PromiseCreateDto;
+import org.kkumulkkum.server.dto.promise.response.MainPromiseDto;
 import org.kkumulkkum.server.dto.promise.response.PromiseDto;
 import org.kkumulkkum.server.dto.promise.response.PromisesDto;
 import org.kkumulkkum.server.service.promise.PromiseService;
@@ -57,4 +58,10 @@ public class PromiseController {
         return ResponseEntity.ok().body(promiseService.getPromise(promiseId));
     }
 
+    @GetMapping("/promises/today/next")
+    public ResponseEntity<MainPromiseDto> getNextPromise(
+            @UserId final Long userId
+    ) {
+        return ResponseEntity.ok().body(promiseService.getNextPromise(userId));
+    }
 }

--- a/src/main/java/org/kkumulkkum/server/controller/PromiseController.java
+++ b/src/main/java/org/kkumulkkum/server/controller/PromiseController.java
@@ -6,6 +6,7 @@ import org.kkumulkkum.server.annotation.IsMember;
 import org.kkumulkkum.server.annotation.UserId;
 import org.kkumulkkum.server.dto.promise.PromiseCreateDto;
 import org.kkumulkkum.server.dto.promise.response.MainPromiseDto;
+import org.kkumulkkum.server.dto.promise.response.MainPromisesDto;
 import org.kkumulkkum.server.dto.promise.response.PromiseDto;
 import org.kkumulkkum.server.dto.promise.response.PromisesDto;
 import org.kkumulkkum.server.service.promise.PromiseService;
@@ -63,5 +64,12 @@ public class PromiseController {
             @UserId final Long userId
     ) {
         return ResponseEntity.ok().body(promiseService.getNextPromise(userId));
+    }
+
+    @GetMapping("/promises/upcoming")
+    public ResponseEntity<MainPromisesDto> getUpcomingPromise(
+            @UserId final Long userId
+    ) {
+        return ResponseEntity.ok().body(promiseService.getUpcomingPromises(userId));
     }
 }

--- a/src/main/java/org/kkumulkkum/server/dto/promise/response/MainPromiseDto.java
+++ b/src/main/java/org/kkumulkkum/server/dto/promise/response/MainPromiseDto.java
@@ -1,0 +1,33 @@
+package org.kkumulkkum.server.dto.promise.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import org.kkumulkkum.server.domain.Promise;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+
+public record MainPromiseDto(
+        Long id,
+        String name,
+        String meetingName,
+        String dressLevel,
+        int dDay,
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd")
+        LocalDateTime date,
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "a h:mm", locale = "en")
+        LocalDateTime time,
+        String placeName
+) {
+    public static MainPromiseDto from(Promise promise) {
+        return new MainPromiseDto(
+                promise.getId(),
+                promise.getName(),
+                promise.getMeeting().getName(),
+                promise.getDressUpLevel().getContent(),
+                (int) ChronoUnit.DAYS.between(LocalDateTime.now(), promise.getTime()),
+                promise.getTime(),
+                promise.getTime(),
+                promise.getPlaceName()
+        );
+    }
+}

--- a/src/main/java/org/kkumulkkum/server/dto/promise/response/MainPromisesDto.java
+++ b/src/main/java/org/kkumulkkum/server/dto/promise/response/MainPromisesDto.java
@@ -1,0 +1,17 @@
+package org.kkumulkkum.server.dto.promise.response;
+
+import org.kkumulkkum.server.domain.Promise;
+
+import java.util.List;
+
+public record MainPromisesDto(
+        List<MainPromiseDto> promises
+) {
+    public static MainPromisesDto from(List<Promise> promises) {
+        return new MainPromisesDto(
+                promises.stream()
+                        .map(MainPromiseDto::from)
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/org/kkumulkkum/server/repository/PromiseRepository.java
+++ b/src/main/java/org/kkumulkkum/server/repository/PromiseRepository.java
@@ -1,11 +1,27 @@
 package org.kkumulkkum.server.repository;
 
 import org.kkumulkkum.server.domain.Promise;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface PromiseRepository extends JpaRepository<Promise, Long> {
 
     List<Promise> findAllByMeetingId(Long meetingId);
+
+    @Query("SELECT p FROM Participant pt " +
+            "JOIN pt.member m " +
+            "JOIN pt.promise p " +
+            "WHERE m.user.id = :userId " +
+            "AND p.time >= :startOfDay " +
+            "AND p.time < :startOfNextDay " +
+            "AND p.time > CURRENT_TIMESTAMP " +
+            "AND p.isCompleted = false " +
+            "ORDER BY p.time ASC, p.createdAt ASC")
+    Page<Promise> findNextPromiseByUserId(Long userId, LocalDateTime startOfDay, LocalDateTime startOfNextDay, Pageable pageable);
+
 }

--- a/src/main/java/org/kkumulkkum/server/repository/PromiseRepository.java
+++ b/src/main/java/org/kkumulkkum/server/repository/PromiseRepository.java
@@ -24,4 +24,22 @@ public interface PromiseRepository extends JpaRepository<Promise, Long> {
             "ORDER BY p.time ASC, p.createdAt ASC")
     Page<Promise> findNextPromiseByUserId(Long userId, LocalDateTime startOfDay, LocalDateTime startOfNextDay, Pageable pageable);
 
+    @Query("SELECT p FROM Participant pt " +
+            "JOIN pt.member m " +
+            "JOIN pt.promise p " +
+            "WHERE m.user.id = :userId " +
+            "AND p.time > CURRENT_TIMESTAMP " +
+            "AND p.isCompleted = false " +
+            "AND p.id <> :nextPromiseId " +
+            "ORDER BY p.time ASC, p.createdAt ASC")
+    Page<Promise> findUpcomingPromisesExcludingNext(Long userId, Long nextPromiseId, Pageable pageable);
+
+    @Query("SELECT p FROM Participant pt " +
+            "JOIN pt.member m " +
+            "JOIN pt.promise p " +
+            "WHERE m.user.id = :userId " +
+            "AND p.time > CURRENT_TIMESTAMP " +
+            "AND p.isCompleted = false " +
+            "ORDER BY p.time ASC, p.createdAt ASC")
+    Page<Promise> findUpcomingPromises(Long userId, Pageable pageable);
 }

--- a/src/main/java/org/kkumulkkum/server/service/promise/PromiseRetriever.java
+++ b/src/main/java/org/kkumulkkum/server/service/promise/PromiseRetriever.java
@@ -5,8 +5,11 @@ import org.kkumulkkum.server.domain.Promise;
 import org.kkumulkkum.server.exception.PromiseException;
 import org.kkumulkkum.server.exception.code.PromiseErrorCode;
 import org.kkumulkkum.server.repository.PromiseRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Component;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Component
@@ -21,6 +24,14 @@ public class PromiseRetriever {
 
     public Promise findById(Long id) {
         return promiseRepository.findById(id)
+                .orElseThrow(() -> new PromiseException(PromiseErrorCode.NOT_FOUND_PROMISE));
+    }
+
+    public Promise findNextPromiseByUserId(Long userId, LocalDateTime startOfDay, LocalDateTime startOfNextDay) {
+        Page<Promise> promisePage = promiseRepository.findNextPromiseByUserId(userId, startOfDay, startOfNextDay, PageRequest.of(0,1));
+
+        return promisePage.stream()
+                .findFirst()
                 .orElseThrow(() -> new PromiseException(PromiseErrorCode.NOT_FOUND_PROMISE));
     }
 }

--- a/src/main/java/org/kkumulkkum/server/service/promise/PromiseRetriever.java
+++ b/src/main/java/org/kkumulkkum/server/service/promise/PromiseRetriever.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Component
 @RequiredArgsConstructor
@@ -33,5 +34,15 @@ public class PromiseRetriever {
         return promisePage.stream()
                 .findFirst()
                 .orElseThrow(() -> new PromiseException(PromiseErrorCode.NOT_FOUND_PROMISE));
+    }
+
+    public List<Promise> findUpcomingPromisesExcludingNext(Long userId, Promise nextPromise, int limit) {
+        Page<Promise> promisePage = promiseRepository.findUpcomingPromisesExcludingNext(userId, nextPromise.getId(), PageRequest.of(0, limit));
+        return promisePage.stream().collect(Collectors.toList());
+    }
+
+    public List<Promise> findUpcomingPromises(Long userId, int limit) {
+        Page<Promise> promisePage = promiseRepository.findUpcomingPromises(userId, PageRequest.of(0, limit));
+        return promisePage.stream().collect(Collectors.toList());
     }
 }

--- a/src/main/java/org/kkumulkkum/server/service/promise/PromiseService.java
+++ b/src/main/java/org/kkumulkkum/server/service/promise/PromiseService.java
@@ -7,13 +7,15 @@ import org.kkumulkkum.server.domain.Member;
 import org.kkumulkkum.server.domain.Participant;
 import org.kkumulkkum.server.domain.Promise;
 import org.kkumulkkum.server.dto.promise.PromiseCreateDto;
+import org.kkumulkkum.server.dto.promise.response.MainPromiseDto;
 import org.kkumulkkum.server.dto.promise.response.PromiseDto;
 import org.kkumulkkum.server.dto.promise.response.PromisesDto;
 import org.kkumulkkum.server.service.participant.ParticipantSaver;
-import org.kkumulkkum.server.service.member.MemberRetreiver;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
@@ -76,5 +78,12 @@ public class PromiseService {
     ) {
         Promise promise = promiseRetriever.findById(promiseId);
         return PromiseDto.from(promise);
+    }
+
+    @Transactional(readOnly = true)
+    public MainPromiseDto getNextPromise(final Long userId) {
+        LocalDateTime startOfDay = LocalDate.now().atStartOfDay();
+        LocalDateTime startOfNextDay = startOfDay.plusDays(1);
+        return MainPromiseDto.from(promiseRetriever.findNextPromiseByUserId(userId, startOfDay, startOfNextDay));
     }
 }

--- a/src/main/java/org/kkumulkkum/server/service/promise/PromiseService.java
+++ b/src/main/java/org/kkumulkkum/server/service/promise/PromiseService.java
@@ -8,8 +8,10 @@ import org.kkumulkkum.server.domain.Participant;
 import org.kkumulkkum.server.domain.Promise;
 import org.kkumulkkum.server.dto.promise.PromiseCreateDto;
 import org.kkumulkkum.server.dto.promise.response.MainPromiseDto;
+import org.kkumulkkum.server.dto.promise.response.MainPromisesDto;
 import org.kkumulkkum.server.dto.promise.response.PromiseDto;
 import org.kkumulkkum.server.dto.promise.response.PromisesDto;
+import org.kkumulkkum.server.exception.PromiseException;
 import org.kkumulkkum.server.service.participant.ParticipantSaver;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -85,5 +87,18 @@ public class PromiseService {
         LocalDateTime startOfDay = LocalDate.now().atStartOfDay();
         LocalDateTime startOfNextDay = startOfDay.plusDays(1);
         return MainPromiseDto.from(promiseRetriever.findNextPromiseByUserId(userId, startOfDay, startOfNextDay));
+    }
+
+    @Transactional(readOnly = true)
+    public MainPromisesDto getUpcomingPromises(final Long userId) {
+        LocalDateTime startOfDay = LocalDate.now().atStartOfDay();
+        LocalDateTime startOfNextDay = startOfDay.plusDays(1);
+        try {
+            Promise nextPromise = promiseRetriever.findNextPromiseByUserId(userId, startOfDay, startOfNextDay);
+            return MainPromisesDto.from(promiseRetriever.findUpcomingPromisesExcludingNext(userId, nextPromise, 4));
+        } catch (PromiseException e) {
+            // 오늘의 약속이 없는 경우
+            return MainPromisesDto.from(promiseRetriever.findUpcomingPromises(userId, 4));
+        }
     }
 }


### PR DESCRIPTION
## Related issue 🛠
[//]: # (해당하는 이슈 번호 달아주기)
- closed #40

## Work Description ✏️
[//]: # (작업 내용 간단 소개)
- 메인홈 약속 조회 관련 API들을 구현합니다. (오늘 가장 가까운 약속 조회, 다가올 약속 목록 조회)

## Uncompleted Tasks 😅
[//]: # (없다면 N/A)
- [ ] N/A

## To Reviewers 📢
[//]: # (reviewer가 알면 좋은 내용들)