### PR TITLE
[feat] 소셜 로그인 API 관련 수정 작업 (fcm Token 추가)

### DIFF
--- a/src/main/java/org/kkumulkkum/server/controller/AuthController.java
+++ b/src/main/java/org/kkumulkkum/server/controller/AuthController.java
@@ -7,6 +7,7 @@ import org.kkumulkkum.server.annotation.UserId;
 import org.kkumulkkum.server.constant.Constant;
 import org.kkumulkkum.server.dto.auth.request.UserLoginDto;
 import org.kkumulkkum.server.dto.auth.response.JwtTokenDto;
+import org.kkumulkkum.server.dto.auth.response.UserTokenDto;
 import org.kkumulkkum.server.service.auth.AuthService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -19,7 +20,7 @@ public class AuthController {
     private final AuthService authService;
 
     @PostMapping("/auth/signin")
-    public ResponseEntity<JwtTokenDto> signin(
+    public ResponseEntity<UserTokenDto> signin(
             @NotNull @RequestHeader(Constant.AUTHORIZATION_HEADER) final String providerToken,
             @Valid @RequestBody final UserLoginDto userLoginDto
     ) {

--- a/src/main/java/org/kkumulkkum/server/domain/UserInfo.java
+++ b/src/main/java/org/kkumulkkum/server/domain/UserInfo.java
@@ -15,6 +15,8 @@ public class UserInfo extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    private String fcmToken;
+
     private String name;
 
     private String profileImg;
@@ -46,6 +48,11 @@ public class UserInfo extends BaseTimeEntity {
         this.tardyCount = 0;
         this.user = user;
         this.tardySum = 0L;
+    }
+
+
+    public void updateFcmToken(String fcmToken) {
+        this.fcmToken = fcmToken;
     }
 
     public void updateImage(String imageUrl) {

--- a/src/main/java/org/kkumulkkum/server/dto/auth/request/UserLoginDto.java
+++ b/src/main/java/org/kkumulkkum/server/dto/auth/request/UserLoginDto.java
@@ -5,6 +5,8 @@ import org.kkumulkkum.server.domain.enums.Provider;
 
 public record UserLoginDto(
         @NotNull
-        Provider provider
+        Provider provider,
+        @NotNull
+        String fcmToken
 ) {
 }

--- a/src/main/java/org/kkumulkkum/server/dto/auth/response/UserTokenDto.java
+++ b/src/main/java/org/kkumulkkum/server/dto/auth/response/UserTokenDto.java
@@ -1,0 +1,15 @@
+package org.kkumulkkum.server.dto.auth.response;
+
+import org.kkumulkkum.server.domain.UserInfo;
+
+public record UserTokenDto(
+        String name,
+        JwtTokenDto jwtTokenDto
+) {
+    public static UserTokenDto of(UserInfo userInfo, JwtTokenDto tokens) {
+        return new UserTokenDto(
+                userInfo.getName(),
+                tokens
+        );
+    }
+}

--- a/src/main/java/org/kkumulkkum/server/service/auth/AuthService.java
+++ b/src/main/java/org/kkumulkkum/server/service/auth/AuthService.java
@@ -12,6 +12,7 @@ import org.kkumulkkum.server.domain.enums.Provider;
 import org.kkumulkkum.server.domain.enums.Role;
 import org.kkumulkkum.server.dto.auth.request.UserLoginDto;
 import org.kkumulkkum.server.dto.auth.response.JwtTokenDto;
+import org.kkumulkkum.server.dto.auth.response.UserTokenDto;
 import org.kkumulkkum.server.exception.AuthException;
 import org.kkumulkkum.server.exception.code.AuthErrorCode;
 import org.kkumulkkum.server.service.user.UserRetriever;
@@ -37,14 +38,14 @@ public class AuthService {
     private final UserInfoRetriever userInfoRetriever;
 
     @Transactional
-    public JwtTokenDto signin(final String providerToken, final UserLoginDto userLoginDto) {
+    public UserTokenDto signin(final String providerToken, final UserLoginDto userLoginDto) {
         SocialUserDto socialUserDto = getSocialInfo(providerToken, userLoginDto);
         User user = loadOrCreateUser(userLoginDto.provider(), socialUserDto);
         UserInfo userInfo = userInfoRetriever.findByUserId(user.getId());
         userInfo.updateFcmToken(userLoginDto.fcmToken());
         JwtTokenDto tokens = jwtTokenProvider.issueTokens(user.getId());
         saveToken(user.getId(), tokens);
-        return tokens;
+        return UserTokenDto.of(userInfo, tokens);
     }
 
     @Transactional

--- a/src/main/java/org/kkumulkkum/server/service/auth/AuthService.java
+++ b/src/main/java/org/kkumulkkum/server/service/auth/AuthService.java
@@ -16,6 +16,7 @@ import org.kkumulkkum.server.exception.AuthException;
 import org.kkumulkkum.server.exception.code.AuthErrorCode;
 import org.kkumulkkum.server.service.user.UserRetriever;
 import org.kkumulkkum.server.service.user.UserSaver;
+import org.kkumulkkum.server.service.userInfo.UserInfoRetriever;
 import org.kkumulkkum.server.service.userInfo.UserInfoSaver;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -33,11 +34,14 @@ public class AuthService {
     private final JwtTokenProvider jwtTokenProvider;
     private final TokenRetriever tokenRetriever;
     private final TokenRemover tokenRemover;
+    private final UserInfoRetriever userInfoRetriever;
 
     @Transactional
     public JwtTokenDto signin(final String providerToken, final UserLoginDto userLoginDto) {
         SocialUserDto socialUserDto = getSocialInfo(providerToken, userLoginDto);
         User user = loadOrCreateUser(userLoginDto.provider(), socialUserDto);
+        UserInfo userInfo = userInfoRetriever.findByUserId(user.getId());
+        userInfo.updateFcmToken(userLoginDto.fcmToken());
         JwtTokenDto tokens = jwtTokenProvider.issueTokens(user.getId());
         saveToken(user.getId(), tokens);
         return tokens;


### PR DESCRIPTION
## Related issue 🛠
[//]: # (해당하는 이슈 번호 달아주기)
- closed #46 

## Work Description ✏️
[//]: # (작업 내용 간단 소개)
- userInfo 엔티티에 fcmToken 추가해주었습니다.
- signin할 때마다 fcmToken을 업데이트 해주도록 했습니다.
- 로그인시 반환되는 값에 user의 name을 추가해주었습니다.

## Uncompleted Tasks 😅
[//]: # (없다면 N/A)
- [ ] N/A

## To Reviewers 📢
[//]: # (reviewer가 알면 좋은 내용들)