### PR TITLE
[fix] S3Service 이미지 외부 URL 생성

### DIFF
--- a/src/main/java/org/kkumulkkum/server/external/S3Service.java
+++ b/src/main/java/org/kkumulkkum/server/external/S3Service.java
@@ -45,7 +45,7 @@ public class S3Service {
 
         RequestBody requestBody = RequestBody.fromBytes(image.getBytes());
         s3Client.putObject(request, requestBody);
-        return key;
+        return s3Client.utilities().getUrl(builder -> builder.bucket(bucketName).key(key)).toExternalForm();
     }
 
     public void deleteImage(String key) throws IOException {


### PR DESCRIPTION
## Related issue 🛠
[//]: # (해당하는 이슈 번호 달아주기)
- closed #50 

## Work Description ✏️
[//]: # (작업 내용 간단 소개)
- S3Service에 이미지의 외부 URL을 생성하여 반환하도록 하여, API responseBody에도 외부 URL을 내려주도록 수정했습니다.

## Uncompleted Tasks 😅
[//]: # (없다면 N/A)
- [ ] N/A

## To Reviewers 📢
[//]: # (reviewer가 알면 좋은 내용들)