### PR TITLE
[fix] 모임 생성 API에 반환 값에 meetingId 추가

### DIFF
--- a/src/main/java/org/kkumulkkum/server/controller/MeetingController.java
+++ b/src/main/java/org/kkumulkkum/server/controller/MeetingController.java
@@ -31,7 +31,7 @@ public class MeetingController {
     ) {
         CreatedMeetingDto createdMeetingDto = meetingService.createMeeting(userId, meetingCreateDto);
         return ResponseEntity
-                .created(URI.create(createdMeetingDto.id().toString()))
+                .created(URI.create(createdMeetingDto.meetingId().toString()))
                 .body(createdMeetingDto);
     }
 

--- a/src/main/java/org/kkumulkkum/server/dto/meeting/response/CreatedMeetingDto.java
+++ b/src/main/java/org/kkumulkkum/server/dto/meeting/response/CreatedMeetingDto.java
@@ -1,10 +1,7 @@
 package org.kkumulkkum.server.dto.meeting.response;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-
 public record CreatedMeetingDto(
-        @JsonIgnore
-        Long id,
+        Long meetingId,
         String invitationCode
 ) {
 }


### PR DESCRIPTION
## Related issue 🛠
[//]: # (해당하는 이슈 번호 달아주기)
- closed #79 

## Work Description ✏️
[//]: # (작업 내용 간단 소개)
- 모임 생성 API에 반환 값에 meetingId 추가

## Uncompleted Tasks 😅
[//]: # (없다면 N/A)
- [ ] N/A

## To Reviewers 📢
[//]: # (reviewer가 알면 좋은 내용들)