### PR TITLE
[fix] 로그 레벨 수정 및 로그에 정보 추가

### DIFF
--- a/src/main/java/org/kkumulkkum/server/advice/GlobalExceptionHandler.java
+++ b/src/main/java/org/kkumulkkum/server/advice/GlobalExceptionHandler.java
@@ -20,7 +20,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(value = {UserException.class})
     public ResponseEntity<UserErrorCode> handleMeetingException(UserException e) {
-        log.error("GlobalExceptionHandler catch UserException : {}", e.getErrorCode().getMessage());
+        log.warn("GlobalExceptionHandler catch UserException : {}", e.getErrorCode().getMessage());
         return ResponseEntity
                 .status(e.getErrorCode().getHttpStatus())
                 .body(e.getErrorCode());
@@ -28,7 +28,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(value = {MeetingException.class})
     public ResponseEntity<MeetingErrorCode> handleMeetingException(MeetingException e) {
-        log.error("GlobalExceptionHandler catch MeetingException : {}", e.getErrorCode().getMessage());
+        log.warn("GlobalExceptionHandler catch MeetingException : {}", e.getErrorCode().getMessage());
         return ResponseEntity
                 .status(e.getErrorCode().getHttpStatus())
                 .body(e.getErrorCode());
@@ -36,7 +36,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(value = {AuthException.class})
     public ResponseEntity<AuthErrorCode> handleAuthException(AuthException e) {
-        log.error("GlobalExceptionHandler catch AuthException : {}", e.getErrorCode().getMessage());
+        log.warn("GlobalExceptionHandler catch AuthException : {}", e.getErrorCode().getMessage());
         return ResponseEntity
                 .status(e.getErrorCode().getHttpStatus())
                 .body(e.getErrorCode());
@@ -44,7 +44,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(value = {ParticipantException.class})
     public ResponseEntity<ParticipantErrorCode> handleParticipantException(ParticipantException e) {
-        log.error("GlobalExceptionHandler catch ParticipantException : {}", e.getErrorCode().getMessage());
+        log.warn("GlobalExceptionHandler catch ParticipantException : {}", e.getErrorCode().getMessage());
         return ResponseEntity
                 .status(e.getErrorCode().getHttpStatus())
                 .body(e.getErrorCode());
@@ -52,7 +52,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(value = {PromiseException.class})
     public ResponseEntity<PromiseErrorCode> handlePromiseException(PromiseException e) {
-        log.error("GlobalExceptionHandler catch PromiseException : {}", e.getErrorCode().getMessage());
+        log.warn("GlobalExceptionHandler catch PromiseException : {}", e.getErrorCode().getMessage());
         return ResponseEntity
                 .status(e.getErrorCode().getHttpStatus())
                 .body(e.getErrorCode());
@@ -60,7 +60,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(value = {MemberException.class})
     public ResponseEntity<MemberErrorCode> handleMemberException(MemberException e) {
-        log.error("GlobalExceptionHandler catch MemberException : {}", e.getErrorCode().getMessage());
+        log.warn("GlobalExceptionHandler catch MemberException : {}", e.getErrorCode().getMessage());
         return ResponseEntity
                 .status(e.getErrorCode().getHttpStatus())
                 .body(e.getErrorCode());
@@ -68,7 +68,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(value = {AwsException.class})
     public ResponseEntity<AwsErrorCode> handleAwsException(AwsException e) {
-        log.error("GlobalExceptionHandler catch AwsException : {}", e.getErrorCode().getMessage());
+        log.warn("GlobalExceptionHandler catch AwsException : {}", e.getErrorCode().getMessage());
         return ResponseEntity
                 .status(e.getErrorCode().getHttpStatus())
                 .body(e.getErrorCode());
@@ -76,7 +76,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(value = {FirebaseException.class})
     public ResponseEntity<FirebaseErrorCode> handleAwsException(FirebaseException e) {
-        log.error("GlobalExceptionHandler catch FirebaseException : {}", e.getErrorCode().getMessage());
+        log.warn("GlobalExceptionHandler catch FirebaseException : {}", e.getErrorCode().getMessage());
         return ResponseEntity
                 .status(e.getErrorCode().getHttpStatus())
                 .body(e.getErrorCode());
@@ -85,7 +85,7 @@ public class GlobalExceptionHandler {
     // 도메인 관련된 에러가 아닐 경우
     @ExceptionHandler(value = {BusinessException.class})
     public ResponseEntity<BusinessErrorCode> handleBusinessException(BusinessException e) {
-        log.error("GlobalExceptionHandler catch BusinessException : {}", e.getErrorCode().getMessage());
+        log.warn("GlobalExceptionHandler catch BusinessException : {}", e.getErrorCode().getMessage());
         return ResponseEntity
                 .status(e.getErrorCode().getHttpStatus())
                 .body(e.getErrorCode());
@@ -94,7 +94,7 @@ public class GlobalExceptionHandler {
     // 존재하지 않는 요청에 대한 예외
     @ExceptionHandler(value = {NoHandlerFoundException.class})
     public ResponseEntity<BusinessErrorCode> handleNoPageFoundException(NoHandlerFoundException e) {
-        log.error("GlobalExceptionHandler catch NoHandlerFoundException : {}", BusinessErrorCode.NOT_FOUND_END_POINT.getMessage());
+        log.warn("GlobalExceptionHandler catch NoHandlerFoundException : {}", BusinessErrorCode.NOT_FOUND_END_POINT.getMessage());
         return ResponseEntity
                 .status(BusinessErrorCode.NOT_FOUND_END_POINT.getHttpStatus())
                 .body(BusinessErrorCode.NOT_FOUND_END_POINT);
@@ -103,7 +103,7 @@ public class GlobalExceptionHandler {
     // 잘못된 Method로 요청한 경우
     @ExceptionHandler(value = {HttpRequestMethodNotSupportedException.class})
     public ResponseEntity<BusinessErrorCode> handleNoPageFoundException(HttpRequestMethodNotSupportedException e) {
-        log.error("GlobalExceptionHandler catch NoHandlerFoundException : {}", BusinessErrorCode.NOT_FOUND_END_POINT.getMessage());
+        log.warn("GlobalExceptionHandler catch NoHandlerFoundException : {}", BusinessErrorCode.NOT_FOUND_END_POINT.getMessage());
         return ResponseEntity
                 .status(BusinessErrorCode.METHOD_NOT_ALLOWED.getHttpStatus())
                 .body(BusinessErrorCode.METHOD_NOT_ALLOWED);
@@ -111,7 +111,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(value = {HandlerMethodValidationException.class, MethodArgumentNotValidException.class})
     public ResponseEntity<BusinessErrorCode> handleValidationException(Exception e) {
-        log.error("GlobalExceptionHandler catch MethodArgumentNotValidException : {}", e.getMessage());
+        log.warn("GlobalExceptionHandler catch MethodArgumentNotValidException : {}", e.getMessage());
         return ResponseEntity
                 .status(BusinessErrorCode.INVALID_ARGUMENTS.getHttpStatus())
                 .body(BusinessErrorCode.INVALID_ARGUMENTS);
@@ -119,7 +119,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(value = {MissingServletRequestParameterException.class})
     public ResponseEntity<BusinessErrorCode> handleMissingParameterException(MissingServletRequestParameterException e) {
-        log.error("GlobalExceptionHandler catch MissingServletRequestParameterException : {}", e.getMessage());
+        log.warn("GlobalExceptionHandler catch MissingServletRequestParameterException : {}", e.getMessage());
         return ResponseEntity
                 .status(BusinessErrorCode.MISSING_REQUIRED_PARAM.getHttpStatus())
                 .body(BusinessErrorCode.MISSING_REQUIRED_PARAM);
@@ -127,7 +127,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(value = {MissingRequestHeaderException.class})
     public ResponseEntity<BusinessErrorCode> handleMissingHeaderException(MissingRequestHeaderException e) {
-        log.error("GlobalExceptionHandler catch MissingRequestHeaderException : {}", e.getMessage());
+        log.warn("GlobalExceptionHandler catch MissingRequestHeaderException : {}", e.getMessage());
         return ResponseEntity
                 .status(BusinessErrorCode.MISSING_REQUIRED_HEADER.getHttpStatus())
                 .body(BusinessErrorCode.MISSING_REQUIRED_HEADER);
@@ -135,8 +135,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(MaxUploadSizeExceededException.class)
     public ResponseEntity<BusinessErrorCode> handleMaxSizeException(MaxUploadSizeExceededException e) {
-        log.error("GlobalExceptionHandler catch MaxUploadSizeExceededException : {}", e.getMessage());
-        e.printStackTrace();
+        log.warn("GlobalExceptionHandler catch MaxUploadSizeExceededException : {}", e.getMessage());
         return ResponseEntity
                 .status(BusinessErrorCode.PAYLOAD_TOO_LARGE.getHttpStatus())
                 .body(BusinessErrorCode.PAYLOAD_TOO_LARGE);

--- a/src/main/java/org/kkumulkkum/server/log/discord/DiscordAppender.java
+++ b/src/main/java/org/kkumulkkum/server/log/discord/DiscordAppender.java
@@ -69,7 +69,7 @@ public class DiscordAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
                         false)
                 .addField(
                         "[" + MDCUtil.REQUEST_URI_MDC + "]",
-                        StringEscapeUtils.escapeJson(mdcPropertyMap.get(MDCUtil.REQUEST_URI_MDC)),
+                        StringEscapeUtils.escapeJson(mdcPropertyMap.get(MDCUtil.REQUEST_METHOD_MDC) +"\n"+ mdcPropertyMap.get(MDCUtil.REQUEST_URI_MDC)),
                         false)
                 .addField(
                         "[" + MDCUtil.USER_IP_MDC + "]",

--- a/src/main/java/org/kkumulkkum/server/log/filter/MDCFilter.java
+++ b/src/main/java/org/kkumulkkum/server/log/filter/MDCFilter.java
@@ -29,6 +29,7 @@ public class MDCFilter extends OncePerRequestFilter {
         HttpServletRequest httpReq = WebUtils.getNativeRequest(request, HttpServletRequest.class);
 
         MDCUtil.setJsonValue(MDCUtil.REQUEST_URI_MDC, HttpRequestUtil.getRequestUri(Objects.requireNonNull(httpReq)));
+        MDCUtil.setJsonValue(MDCUtil.REQUEST_METHOD_MDC, HttpRequestUtil.getRequestMethod(Objects.requireNonNull(httpReq)));
         MDCUtil.setJsonValue(MDCUtil.USER_IP_MDC, HttpRequestUtil.getUserIP(Objects.requireNonNull(httpReq)));
         MDCUtil.setJsonValue(MDCUtil.HEADER_MAP_MDC, HttpRequestUtil.getHeaderMap(httpReq));
         MDCUtil.setJsonValue(MDCUtil.USER_INFO, SecurityContextHolder.getContext().getAuthentication().getPrincipal());

--- a/src/main/java/org/kkumulkkum/server/log/util/HttpRequestUtil.java
+++ b/src/main/java/org/kkumulkkum/server/log/util/HttpRequestUtil.java
@@ -21,6 +21,10 @@ public class HttpRequestUtil {
         return request.getRequestURI();
     }
 
+    public static String getRequestMethod(HttpServletRequest request) {
+        return "[{}]".replace("{}", request.getMethod());
+    }
+
     public static Map<String, String> getHeaderMap(HttpServletRequest request) {
         Map<String, String> headerMap = new HashMap<>();
         request.getHeaderNames().asIterator()

--- a/src/main/java/org/kkumulkkum/server/log/util/MDCUtil.java
+++ b/src/main/java/org/kkumulkkum/server/log/util/MDCUtil.java
@@ -11,6 +11,7 @@ import org.slf4j.spi.MDCAdapter;
 public class MDCUtil {
 
     public static final String REQUEST_URI_MDC = "이용자 요청 URI 정보";
+    public static final String REQUEST_METHOD_MDC = "이용자 요청 메소드 정보";
     public static final String USER_IP_MDC = "이용자 IP 정보";
 //    public static final String USER_REQUEST_COOKIES = "이용자 Cookie 정보";
     public static final String USER_INFO = "이용자 로그인 정보";


### PR DESCRIPTION
## Related issue 🛠
[//]: # (해당하는 이슈 번호 달아주기)
- closed #75

## Work Description ✏️
[//]: # (작업 내용 간단 소개)
- GlobalExceptionHandler에서 핸들링하지 않는 Exception만 discord를 받도록 로그 레벨 수정
- 로그에 Method 정보를 입력

## Uncompleted Tasks 😅
[//]: # (없다면 N/A)
- [ ] AOP 적용(현재 상태에서 굳이 적용할 이유를 찾지 못했음)

## To Reviewers 📢
[//]: # (reviewer가 알면 좋은 내용들)
AOP를 사용하려는 의도가 특정 메소드에만 작동하도록 하는 것이었는데 이미 log level 조정으로 가능하여 AOP의 사용 이유를 상실했습니다.
추가적으로 회원가입 등의 이벤트에 AOP를 다는 것은 이해가 가나 그냥 에러를 AOP로 하는 이유까지는 찾지 못했습니다.