### PR TITLE
[fix] 의미없는 로깅 알림 제거

### DIFF
--- a/src/main/java/org/kkumulkkum/server/auth/JwtExceptionFilter.java
+++ b/src/main/java/org/kkumulkkum/server/auth/JwtExceptionFilter.java
@@ -29,11 +29,11 @@ public class JwtExceptionFilter extends OncePerRequestFilter {
         try {
             filterChain.doFilter(request, response);
         } catch (AuthException e) {
-            log.error("FilterException throw AuthException : {}", e.getErrorCode().getMessage());
+//            log.error("FilterException throw AuthException : {}", e.getErrorCode().getMessage());
             request.setAttribute("exception", e.getErrorCode());
             filterChain.doFilter(request, response);
         } catch (JwtException e) {
-            log.error("FilterException throw JwtException Exception : {}", e.getMessage());
+//            log.error("FilterException throw JwtException Exception : {}", e.getMessage());
             request.setAttribute("exception", AuthErrorCode.UNKNOWN_TOKEN);
             filterChain.doFilter(request, response);
         } catch (Exception e) {


### PR DESCRIPTION
## Related issue 🛠
[//]: # (해당하는 이슈 번호 달아주기)
- closed #86 

## Work Description ✏️
[//]: # (작업 내용 간단 소개)
- 의미없는 알림이 오는 것을 제거했습니다. (에러 원인은 ATK 만료)
<img width="347" alt="스크린샷 2024-08-02 00 43 20" src="https://github.com/user-attachments/assets/958cc5a4-b3f8-4952-b06b-cd7df9ed792e">
- reissue 테스트를 위해 ATK 수명을 1분으로 변경했습니다.

## Uncompleted Tasks 😅
[//]: # (없다면 N/A)
- [ ] N/A

## To Reviewers 📢
[//]: # (reviewer가 알면 좋은 내용들)
일단 메시지를 제거했는데 다음 리팩토링 때 어디어디에 메시지를 다는 것이 좋을지 같이 생각해봅시다.