### PR TITLE
[feat] 회원탈퇴 구현 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ application-local.yml
 application-dev.yml
 application-prod.yml
 *.json
+*.p8

--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,7 @@ dependencies {
 
 	// Social Login
 	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign:4.1.2'
+	implementation 'org.bouncycastle:bcpkix-jdk18on:1.75'
 
 	// Validation
 	implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/src/main/java/org/kkumulkkum/server/auth/openfeign/apple/AppleFeignClient.java
+++ b/src/main/java/org/kkumulkkum/server/auth/openfeign/apple/AppleFeignClient.java
@@ -1,12 +1,32 @@
 package org.kkumulkkum.server.auth.openfeign.apple;
 
 import org.kkumulkkum.server.auth.openfeign.apple.dto.ApplePublicKeys;
+import org.kkumulkkum.server.auth.openfeign.apple.dto.AppleTokenDto;
 import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @FeignClient(name = "apple-public-key-client", url = "https://appleid.apple.com/auth")
 public interface AppleFeignClient {
 
     @GetMapping("/keys")
     ApplePublicKeys getApplePublicKeys();
+
+    @PostMapping(value = "/token", consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+    AppleTokenDto getAppleToken(
+            @RequestParam("client_id") String clientId,
+            @RequestParam("client_secret") String clientSecret,
+            @RequestParam("grant_type") String grantType,
+            @RequestParam("code") String authCode
+    );
+
+    @PostMapping(value = "/revoke", consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+    void revoke(
+            @RequestParam(value = "client_id") String client_id,
+            @RequestParam(value = "client_secret") String client_secret,
+            @RequestParam(value = "token") String token,
+            @RequestParam(value = "token_type_hint") String token_type_hint
+    );
 }

--- a/src/main/java/org/kkumulkkum/server/auth/openfeign/apple/dto/AppleTokenDto.java
+++ b/src/main/java/org/kkumulkkum/server/auth/openfeign/apple/dto/AppleTokenDto.java
@@ -1,0 +1,14 @@
+package org.kkumulkkum.server.auth.openfeign.apple.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record AppleTokenDto(
+        String accessToken,
+        String tokenType,
+        String expiresIn,
+        String refreshToken,
+        String idToken
+) {
+}

--- a/src/main/java/org/kkumulkkum/server/auth/openfeign/apple/service/AppleService.java
+++ b/src/main/java/org/kkumulkkum/server/auth/openfeign/apple/service/AppleService.java
@@ -2,16 +2,23 @@ package org.kkumulkkum.server.auth.openfeign.apple.service;
 
 import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.kkumulkkum.server.auth.openfeign.apple.AppleFeignClient;
 import org.kkumulkkum.server.auth.openfeign.apple.dto.ApplePublicKeys;
+import org.kkumulkkum.server.auth.openfeign.apple.dto.AppleTokenDto;
+import org.kkumulkkum.server.auth.openfeign.apple.verify.AppleClientSecretGenerator;
 import org.kkumulkkum.server.auth.openfeign.apple.verify.AppleJwtParser;
 import org.kkumulkkum.server.auth.openfeign.apple.verify.PublicKeyGenerator;
 import org.kkumulkkum.server.auth.openfeign.kakao.dto.SocialUserDto;
+import org.kkumulkkum.server.exception.AuthException;
+import org.kkumulkkum.server.exception.code.AuthErrorCode;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.security.PublicKey;
 import java.util.Map;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class AppleService {
@@ -22,6 +29,11 @@ public class AppleService {
     private final AppleFeignClient appleFeignClient;
     private final AppleJwtParser appleJwtParser;
     private final PublicKeyGenerator publicKeyGenerator;
+    private final AppleClientSecretGenerator appleClientSecretGenerator;
+
+    @Value("${oauth.apple.client-id}")
+    private String clientId;
+
     public SocialUserDto getSocialUserInfo(String identityToken) {
 
         Map<String, String> headers = appleJwtParser.parseHeaders(identityToken);
@@ -31,4 +43,34 @@ public class AppleService {
         return SocialUserDto.of(claims.get(APPLE_SUBJECT, String.class), claims.get(APPLE_EMAIL, String.class));
     }
 
+    public void revoke(final String authCode) {
+        try {
+            String clientSecret = appleClientSecretGenerator.createClientSecret();
+            String refreshToken = getRefreshToken(authCode, clientSecret);
+            appleFeignClient.revoke(
+                    clientId,
+                    clientSecret,
+                    refreshToken,
+                    "refresh_token"
+            );
+        } catch (Exception e){
+            log.error("apple revoke failed : {}", e.getMessage());
+            throw new AuthException(AuthErrorCode.APPLE_REVOKE_FAILED);
+        }
+    }
+
+    private String getRefreshToken(final String authCode, final String clientSecret) {
+        try {
+            AppleTokenDto appleTokenDto = appleFeignClient.getAppleToken(
+                    clientId,
+                    clientSecret,
+                    "authorization_code",
+                    authCode
+            );
+            return appleTokenDto.refreshToken();
+        } catch (Exception e){
+            log.error("apple token request failed : {}", e.getMessage());
+            throw new AuthException(AuthErrorCode.APPLE_TOKEN_REQUEST_FAILED);
+        }
+    }
 }

--- a/src/main/java/org/kkumulkkum/server/auth/openfeign/apple/verify/AppleClientSecretGenerator.java
+++ b/src/main/java/org/kkumulkkum/server/auth/openfeign/apple/verify/AppleClientSecretGenerator.java
@@ -1,0 +1,71 @@
+package org.kkumulkkum.server.auth.openfeign.apple.verify;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import lombok.RequiredArgsConstructor;
+import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
+import org.bouncycastle.openssl.PEMParser;
+import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.security.PrivateKey;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+@RequiredArgsConstructor
+@Component
+public class AppleClientSecretGenerator {
+
+    private static final String SIGN_ALGORITHM_HEADER_KEY = "alg";
+    private static final String KEY_ID_HEADER_KEY = "kid";
+    private static final String AUDIENCE = "https://appleid.apple.com";
+
+    @Value("${oauth.apple.client-id}")
+    private String clientId;
+
+    @Value("${oauth.apple.key-id}")
+    private String keyId;
+
+    @Value("${oauth.apple.team-id}")
+    private String teamId;
+
+    @Value("${oauth.apple.key-file-path}")
+    private String keyFilePath;
+
+    public String createClientSecret() throws IOException {
+        Date expirationDate = Date.from(LocalDateTime.now().plusDays(30).atZone(ZoneId.systemDefault()).toInstant());
+        Map<String, Object> jwtHeader = new HashMap<>();
+        jwtHeader.put(KEY_ID_HEADER_KEY, keyId); // kid
+        jwtHeader.put(SIGN_ALGORITHM_HEADER_KEY, SignatureAlgorithm.ES256); // alg
+        return Jwts.builder()
+                .setHeaderParams(jwtHeader)
+                .setIssuer(teamId) // iss
+                .setIssuedAt(new Date(System.currentTimeMillis())) // 발행 시간
+                .setExpiration(expirationDate) // 만료 시간
+                .setAudience(AUDIENCE) // aud
+                .setSubject(clientId) // sub
+                .signWith(SignatureAlgorithm.ES256, getPrivateKey())
+                .compact();
+    }
+
+    public PrivateKey getPrivateKey() throws IOException {
+        ClassPathResource resource = new ClassPathResource(keyFilePath); // .p8 key파일 위치
+        String privateKey = new String(Files.readAllBytes(Paths.get(resource.getURI())));
+
+        Reader pemReader = new StringReader(privateKey);
+        PEMParser pemParser = new PEMParser(pemReader);
+        JcaPEMKeyConverter converter = new JcaPEMKeyConverter();
+        PrivateKeyInfo object = (PrivateKeyInfo) pemParser.readObject();
+        return converter.getPrivateKey(object);
+    }
+}

--- a/src/main/java/org/kkumulkkum/server/auth/openfeign/kakao/KakaoFeignClient.java
+++ b/src/main/java/org/kkumulkkum/server/auth/openfeign/kakao/KakaoFeignClient.java
@@ -4,10 +4,19 @@ import org.kkumulkkum.server.auth.openfeign.kakao.dto.KakaoUserDto;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.http.HttpHeaders;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @FeignClient(name = "kakaoFeignClient", url = "https://kapi.kakao.com")
 public interface KakaoFeignClient {
     @GetMapping(value = "/v2/user/me")
     KakaoUserDto getUserInformation(@RequestHeader(HttpHeaders.AUTHORIZATION) String accessToken);
+
+    @PostMapping(value = "/v1/user/unlink")
+    void unlinkUser(
+            @RequestHeader(HttpHeaders.AUTHORIZATION) String adminKey,
+            @RequestParam("target_id_type") String targetIdType,
+            @RequestParam("target_id") Long targetId
+    );
 }

--- a/src/main/java/org/kkumulkkum/server/auth/openfeign/kakao/service/KakaoService.java
+++ b/src/main/java/org/kkumulkkum/server/auth/openfeign/kakao/service/KakaoService.java
@@ -5,11 +5,15 @@ import org.kkumulkkum.server.auth.openfeign.kakao.KakaoFeignClient;
 import org.kkumulkkum.server.auth.openfeign.kakao.dto.KakaoUserDto;
 import org.kkumulkkum.server.auth.openfeign.kakao.dto.SocialUserDto;
 import org.kkumulkkum.server.constant.AuthConstant;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class KakaoService {
+
+    @Value("${oauth.kakao.admin-key}")
+    private String adminKey;
 
     private final KakaoFeignClient kakaoFeignClient;
     public SocialUserDto getSocialUserInfo(String providerToken) {
@@ -17,5 +21,13 @@ public class KakaoService {
         return SocialUserDto.of(
                 kakaoUserDto.id().toString(),
                 kakaoUserDto.kakaoAccount().email());
+    }
+
+    public void unlinkKakaoUser(final String providerId) {
+        kakaoFeignClient.unlinkUser(
+                AuthConstant.GRANT_TYPE + adminKey,
+                AuthConstant.TARGET_ID_TYPE,
+                Long.valueOf(providerId)
+        );
     }
 }

--- a/src/main/java/org/kkumulkkum/server/constant/AuthConstant.java
+++ b/src/main/java/org/kkumulkkum/server/constant/AuthConstant.java
@@ -10,4 +10,11 @@ public class AuthConstant {
     public static final String AUTHORIZATION_HEADER = "Authorization";
     public static final String BEARER_TOKEN_PREFIX = "Bearer ";
     public static final String CHARACTER_ENCODING_UTF8 = "utf-8";
+
+    //kakao
+    public static final String GRANT_TYPE = "kakaoAK ";
+    public static final String TARGET_ID_TYPE = "user_id";
+
+    //apple
+    public static final String APPLE_WITHDRAW_HEADER = "X-Apple-Code";
 }

--- a/src/main/java/org/kkumulkkum/server/controller/AuthController.java
+++ b/src/main/java/org/kkumulkkum/server/controller/AuthController.java
@@ -1,5 +1,6 @@
 package org.kkumulkkum.server.controller;
 
+import com.google.firebase.database.annotations.Nullable;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
@@ -42,4 +43,12 @@ public class AuthController {
         return ResponseEntity.ok(authService.reissue(refreshToken));
     }
 
+    @DeleteMapping("/v1/auth/withdrawal")
+    public ResponseEntity<Void> withdraw(
+            @UserId final Long userId,
+            @Nullable @RequestHeader(value = AuthConstant.APPLE_WITHDRAW_HEADER, required = false) final String authCode
+    ) {
+        authService.withdrawal(userId, authCode);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/org/kkumulkkum/server/exception/code/AuthErrorCode.java
+++ b/src/main/java/org/kkumulkkum/server/exception/code/AuthErrorCode.java
@@ -13,6 +13,8 @@ public enum AuthErrorCode implements DefaultErrorCode {
     CREATE_PUBLIC_KEY_EXCEPTION(HttpStatus.BAD_REQUEST, 40012,"Apple public key 생성에 문제가 발생했습니다."),
     INVALID_APPLE_IDENTITY_TOKEN(HttpStatus.BAD_REQUEST, 40013, "Apple Identity Token 형식이 올바르지 않습니다."),
     EXPIRED_APPLE_IDENTITY_TOKEN(HttpStatus.BAD_REQUEST, 40014, "Apple Identity Token 유효기간이 만료됐습니다."),
+    APPLE_REVOKE_FAILED(HttpStatus.BAD_REQUEST, 40015,"Apple 회원 탈퇴에 실패했습니다."),
+    APPLE_TOKEN_REQUEST_FAILED(HttpStatus.BAD_REQUEST, 40016, "Apple 토큰 요청에 실패했습니다."),
     // 401 UNAUTHORIZED
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, 40110, "인증되지 않은 사용자입니다."),
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, 40111, "올바르지 않은 토큰입니다."),

--- a/src/main/java/org/kkumulkkum/server/repository/MemberRepository.java
+++ b/src/main/java/org/kkumulkkum/server/repository/MemberRepository.java
@@ -34,4 +34,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     boolean existsByPromiseIdAndUserId(Long promiseId, Long userId);
 
     Member findByMeetingIdAndUserId(Long meetingId, Long userId);
+
+    List<Member> findByUserId(Long userId);
 }

--- a/src/main/java/org/kkumulkkum/server/repository/ParticipantRepository.java
+++ b/src/main/java/org/kkumulkkum/server/repository/ParticipantRepository.java
@@ -72,4 +72,5 @@ public interface ParticipantRepository extends JpaRepository<Participant, Long> 
             WHERE p.promise.id = :promiseId AND m.user.id != :userId""")
     List<String> findFcmTokenByPromiseId(Long promiseId, Long userId);
 
+    void deleteByMemberId(Long memberId);
 }

--- a/src/main/java/org/kkumulkkum/server/repository/UserInfoRepository.java
+++ b/src/main/java/org/kkumulkkum/server/repository/UserInfoRepository.java
@@ -15,4 +15,6 @@ public interface UserInfoRepository extends JpaRepository<UserInfo, Long> {
             JOIN FETCH Participant p ON ui.user.id = p.member.user.id
             WHERE p.id = :id""")
     Optional<UserInfo> findByParticipantId(Long id);
+
+    void deleteByUserId(Long userId);
 }

--- a/src/main/java/org/kkumulkkum/server/service/member/MemberRemover.java
+++ b/src/main/java/org/kkumulkkum/server/service/member/MemberRemover.java
@@ -1,0 +1,19 @@
+package org.kkumulkkum.server.service.member;
+
+import lombok.RequiredArgsConstructor;
+import org.kkumulkkum.server.domain.Member;
+import org.kkumulkkum.server.repository.MemberRepository;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class MemberRemover {
+
+    private final MemberRepository memberRepository;
+
+    public void deleteAll(final List<Member> members) {
+        memberRepository.deleteAll(members);
+    }
+}

--- a/src/main/java/org/kkumulkkum/server/service/member/MemberRetreiver.java
+++ b/src/main/java/org/kkumulkkum/server/service/member/MemberRetreiver.java
@@ -35,4 +35,8 @@ public class MemberRetreiver {
     public Member findByMeetingIdAndUserId(Long meetingId, Long userId) {
         return memberRepository.findByMeetingIdAndUserId(meetingId, userId);
     }
+
+    public List<Member> findByUserId(final Long userId) {
+        return memberRepository.findByUserId(userId);
+    }
 }

--- a/src/main/java/org/kkumulkkum/server/service/participant/ParticipantRemover.java
+++ b/src/main/java/org/kkumulkkum/server/service/participant/ParticipantRemover.java
@@ -1,0 +1,16 @@
+package org.kkumulkkum.server.service.participant;
+
+import lombok.RequiredArgsConstructor;
+import org.kkumulkkum.server.repository.ParticipantRepository;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ParticipantRemover {
+
+    private final ParticipantRepository participantRepository;
+
+    public void deleteByMemberId(final Long memberId) {
+        participantRepository.deleteByMemberId(memberId);
+    }
+}

--- a/src/main/java/org/kkumulkkum/server/service/user/UserRemover.java
+++ b/src/main/java/org/kkumulkkum/server/service/user/UserRemover.java
@@ -1,0 +1,18 @@
+package org.kkumulkkum.server.service.user;
+
+import lombok.RequiredArgsConstructor;
+import org.kkumulkkum.server.domain.User;
+import org.kkumulkkum.server.repository.UserRepository;
+import org.kkumulkkum.server.service.userInfo.UserInfoRetriever;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class UserRemover {
+
+    private final UserRepository userRepository;
+
+    public void delete(User user) {
+        userRepository.delete(user);
+    }
+}

--- a/src/main/java/org/kkumulkkum/server/service/userInfo/UserInfoRemover.java
+++ b/src/main/java/org/kkumulkkum/server/service/userInfo/UserInfoRemover.java
@@ -1,0 +1,16 @@
+package org.kkumulkkum.server.service.userInfo;
+
+import lombok.RequiredArgsConstructor;
+import org.kkumulkkum.server.repository.UserInfoRepository;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class UserInfoRemover {
+
+    private final UserInfoRepository userInfoRepository;
+
+    public void deleteByUserId(final Long userId) {
+        userInfoRepository.deleteByUserId(userId);
+    }
+}


### PR DESCRIPTION
## Related issue 🛠
[//]: # (해당하는 이슈 번호 달아주기)
- closed #90 

## Work Description ✏️
[//]: # (작업 내용 간단 소개)
- 카카오 연결 끊기 구현
- 애플 연결 끊기 구현
- 애플 연결 끊기의 경우, 애플 연동해제를 위해 https://appleid.apple.com/auth/revoke 를 사용하였고, 이 때 필요한 token을 만들기 위해  https://appleid.apple.com/auth/token 를 사용하였습니다.
- DB에서 유저 삭제
- participant -> member -> userInfo -> user 순으로 순차적으로 DB에서 삭제해주었습니다.

## Uncompleted Tasks 😅
[//]: # (없다면 N/A)
- [ ] N/A

## To Reviewers 📢
[//]: # (reviewer가 알면 좋은 내용들)
이번에 깜빡하고 커밋메시지에 이슈번호 다는 것을 깜빡했습니다.... 다음부턴 꼭 까먹지 않고 달도록 하겠습니다.!!!!!!!