### PR TITLE
[fix] S3 multipart 이미지 관련 수정 

### DIFF
--- a/src/main/java/org/kkumulkkum/server/external/S3Service.java
+++ b/src/main/java/org/kkumulkkum/server/external/S3Service.java
@@ -22,7 +22,7 @@ public class S3Service {
 
     private final String bucketName;
     private final AwsConfig awsConfig;
-    private static final List<String> IMAGE_EXTENSIONS = Arrays.asList("image/jpeg", "image/png", "image/jpg", "image/webp");
+    private static final List<String> IMAGE_EXTENSIONS = Arrays.asList("image/jpeg", "image/png", "image/jpg", "image/webp", "image/heic");
 
     public S3Service(@Value("${aws-property.s3-bucket-name}") final String bucketName, AwsConfig awsConfig) {
         this.bucketName = bucketName;


### PR DESCRIPTION
## Related issue 🛠
[//]: # (해당하는 이슈 번호 달아주기)
- closed #91 

## Work Description ✏️
[//]: # (작업 내용 간단 소개)
- multipart 이미지 관련 수정했습니다.
- HEIC 확장자 추가해주었습니다.
- 스프링 자체에서 멀티파트 이미지 용량을 1MB 이하로 막아, 5MB로 제한하도록 수정했습니다.
- NGINX 파일 업로드 용량 제한 설정해주었습니다.

## Uncompleted Tasks 😅
[//]: # (없다면 N/A)
- [ ] N/A

## To Reviewers 📢
[//]: # (reviewer가 알면 좋은 내용들)