### PR TITLE
[feat] 약속 조회 관련 API 수정

### DIFF
--- a/src/main/java/org/kkumulkkum/server/controller/PromiseController.java
+++ b/src/main/java/org/kkumulkkum/server/controller/PromiseController.java
@@ -42,7 +42,7 @@ public class PromiseController {
         return ResponseEntity.ok().build();
     }
 
-    @IsMemberByMeetingId(meetingIdParamIndex = 0)
+    @IsMemberByMeetingId(meetingIdParamIndex = 1)
     @GetMapping("/v1/meetings/{meetingId}/promises")
     public ResponseEntity<PromisesDto> getPromises(
             @UserId final Long userId,
@@ -53,12 +53,13 @@ public class PromiseController {
         return ResponseEntity.ok().body(promiseService.getPromises(userId, meetingId, done, isParticipant));
     }
 
-    @IsMemberByPromiseId(promiseIdParamIndex = 0)
+    @IsMemberByPromiseId(promiseIdParamIndex = 1)
     @GetMapping("/v1/promises/{promiseId}")
     public ResponseEntity<PromiseDto> getPromise(
+            @UserId final Long userId,
             @PathVariable("promiseId") final Long promiseId
     ) {
-        return ResponseEntity.ok().body(promiseService.getPromise(promiseId));
+        return ResponseEntity.ok().body(promiseService.getPromise(userId, promiseId));
     }
 
     @GetMapping("/v1/promises/today/next")

--- a/src/main/java/org/kkumulkkum/server/controller/PromiseController.java
+++ b/src/main/java/org/kkumulkkum/server/controller/PromiseController.java
@@ -7,10 +7,7 @@ import org.kkumulkkum.server.annotation.IsMemberByPromiseId;
 import org.kkumulkkum.server.annotation.IsParticipant;
 import org.kkumulkkum.server.annotation.UserId;
 import org.kkumulkkum.server.dto.promise.PromiseCreateDto;
-import org.kkumulkkum.server.dto.promise.response.MainPromiseDto;
-import org.kkumulkkum.server.dto.promise.response.MainPromisesDto;
-import org.kkumulkkum.server.dto.promise.response.PromiseDto;
-import org.kkumulkkum.server.dto.promise.response.PromisesDto;
+import org.kkumulkkum.server.dto.promise.response.*;
 import org.kkumulkkum.server.service.promise.PromiseService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -24,7 +21,7 @@ public class PromiseController {
 
     @IsMemberByMeetingId(meetingIdParamIndex = 1)
     @PostMapping("/v1/meetings/{meetingId}/promises")
-    public ResponseEntity<PromiseDto> createPromise(
+    public ResponseEntity<PromiseAddDto> createPromise(
             @UserId final Long userId,
             @PathVariable final Long meetingId,
             @Valid @RequestBody final PromiseCreateDto createPromiseDto
@@ -55,7 +52,7 @@ public class PromiseController {
 
     @IsMemberByPromiseId(promiseIdParamIndex = 1)
     @GetMapping("/v1/promises/{promiseId}")
-    public ResponseEntity<PromiseDto> getPromise(
+    public ResponseEntity<PromiseDetailDto> getPromise(
             @UserId final Long userId,
             @PathVariable("promiseId") final Long promiseId
     ) {

--- a/src/main/java/org/kkumulkkum/server/controller/PromiseController.java
+++ b/src/main/java/org/kkumulkkum/server/controller/PromiseController.java
@@ -45,10 +45,12 @@ public class PromiseController {
     @IsMemberByMeetingId(meetingIdParamIndex = 0)
     @GetMapping("/v1/meetings/{meetingId}/promises")
     public ResponseEntity<PromisesDto> getPromises(
+            @UserId final Long userId,
             @PathVariable("meetingId") final Long meetingId,
-            @RequestParam(required = false) final Boolean done
+            @RequestParam(required = false) final Boolean done,
+            @RequestParam(required = false) final Boolean isParticipant
     ) {
-        return ResponseEntity.ok().body(promiseService.getPromises(meetingId, done));
+        return ResponseEntity.ok().body(promiseService.getPromises(userId, meetingId, done, isParticipant));
     }
 
     @IsMemberByPromiseId(promiseIdParamIndex = 0)

--- a/src/main/java/org/kkumulkkum/server/dto/meeting/response/MeetingDto.java
+++ b/src/main/java/org/kkumulkkum/server/dto/meeting/response/MeetingDto.java
@@ -8,7 +8,7 @@ import java.time.LocalDateTime;
 public record MeetingDto (
         Long meetingId,
         String name,
-        @JsonFormat(pattern = "yyyy-MM-dd")
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
         LocalDateTime createdAt,
         Long metCount,
         String invitationCode

--- a/src/main/java/org/kkumulkkum/server/dto/promise/response/MainPromiseDto.java
+++ b/src/main/java/org/kkumulkkum/server/dto/promise/response/MainPromiseDto.java
@@ -12,9 +12,7 @@ public record MainPromiseDto(
         String meetingName,
         String dressUpLevel,
         int dDay,
-        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd")
-        LocalDateTime date,
-        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "a h:mm", locale = "en")
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
         LocalDateTime time,
         String placeName
 ) {
@@ -26,7 +24,6 @@ public record MainPromiseDto(
                 promise.getMeeting().getName(),
                 promise.getDressUpLevel().getContent(),
                 dday,
-                promise.getTime(),
                 promise.getTime(),
                 promise.getPlaceName()
         );

--- a/src/main/java/org/kkumulkkum/server/dto/promise/response/MainPromiseDto.java
+++ b/src/main/java/org/kkumulkkum/server/dto/promise/response/MainPromiseDto.java
@@ -19,8 +19,7 @@ public record MainPromiseDto(
         String placeName
 ) {
     public static MainPromiseDto from(Promise promise) {
-        int dday = (int) ChronoUnit.DAYS.between(LocalDateTime.now().toLocalDate(), promise.getTime().toLocalDate());
-        if (dday < 0) dday = 0;
+        int dday = (int) ChronoUnit.DAYS.between(promise.getTime().toLocalDate(), LocalDateTime.now().toLocalDate());
         return new MainPromiseDto(
                 promise.getId(),
                 promise.getName(),

--- a/src/main/java/org/kkumulkkum/server/dto/promise/response/PromiseAddDto.java
+++ b/src/main/java/org/kkumulkkum/server/dto/promise/response/PromiseAddDto.java
@@ -1,0 +1,31 @@
+package org.kkumulkkum.server.dto.promise.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import org.kkumulkkum.server.domain.Promise;
+
+import java.time.LocalDateTime;
+
+public record PromiseAddDto(
+        Long promiseId,
+        String promiseName,
+        String placeName,
+        String address,
+        String roadAddress,
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+        LocalDateTime time,
+        String dressUpLevel,
+        String penalty
+) {
+    public static PromiseAddDto from(Promise promise) {
+        return new PromiseAddDto(
+                promise.getId(),
+                promise.getName(),
+                promise.getPlaceName(),
+                promise.getAddress(),
+                promise.getRoadAddress(),
+                promise.getTime(),
+                promise.getDressUpLevel().getContent(),
+                promise.getPenalty()
+        );
+    }
+}

--- a/src/main/java/org/kkumulkkum/server/dto/promise/response/PromiseDetailDto.java
+++ b/src/main/java/org/kkumulkkum/server/dto/promise/response/PromiseDetailDto.java
@@ -5,7 +5,7 @@ import org.kkumulkkum.server.domain.Promise;
 
 import java.time.LocalDateTime;
 
-public record PromiseDto(
+public record PromiseDetailDto(
         boolean isParticipant,
         Long promiseId,
         String promiseName,
@@ -17,8 +17,8 @@ public record PromiseDto(
         String dressUpLevel,
         String penalty
 ) {
-    public static PromiseDto from(Promise promise, boolean isParticipant) {
-        return new PromiseDto(
+    public static PromiseDetailDto from(Promise promise, boolean isParticipant) {
+        return new PromiseDetailDto(
                 isParticipant,
                 promise.getId(),
                 promise.getName(),

--- a/src/main/java/org/kkumulkkum/server/dto/promise/response/PromiseDto.java
+++ b/src/main/java/org/kkumulkkum/server/dto/promise/response/PromiseDto.java
@@ -11,7 +11,7 @@ public record PromiseDto(
         String placeName,
         String address,
         String roadAddress,
-        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "M월 d일 HH:mm")
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
         LocalDateTime time,
         String dressUpLevel,
         String penalty

--- a/src/main/java/org/kkumulkkum/server/dto/promise/response/PromiseDto.java
+++ b/src/main/java/org/kkumulkkum/server/dto/promise/response/PromiseDto.java
@@ -6,6 +6,7 @@ import org.kkumulkkum.server.domain.Promise;
 import java.time.LocalDateTime;
 
 public record PromiseDto(
+        boolean isParticipant,
         Long promiseId,
         String promiseName,
         String placeName,
@@ -16,8 +17,9 @@ public record PromiseDto(
         String dressUpLevel,
         String penalty
 ) {
-    public static PromiseDto from(Promise promise) {
+    public static PromiseDto from(Promise promise, boolean isParticipant) {
         return new PromiseDto(
+                isParticipant,
                 promise.getId(),
                 promise.getName(),
                 promise.getPlaceName(),

--- a/src/main/java/org/kkumulkkum/server/dto/promise/response/PromisesDto.java
+++ b/src/main/java/org/kkumulkkum/server/dto/promise/response/PromisesDto.java
@@ -30,8 +30,7 @@ public record PromisesDto(
             String placeName
     ) {
         public static PromiseDto from(Promise promise) {
-            int dday = (int) ChronoUnit.DAYS.between(LocalDateTime.now().toLocalDate(), promise.getTime().toLocalDate());
-            if (dday < 0) dday = 0;
+            int dday = (int) ChronoUnit.DAYS.between(promise.getTime().toLocalDate(), LocalDateTime.now().toLocalDate());
             return new PromiseDto(
                     promise.getId(),
                     promise.getName(),

--- a/src/main/java/org/kkumulkkum/server/dto/promise/response/PromisesDto.java
+++ b/src/main/java/org/kkumulkkum/server/dto/promise/response/PromisesDto.java
@@ -23,9 +23,7 @@ public record PromisesDto(
             Long promiseId,
             String name,
             int dDay,
-            @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd")
-            LocalDateTime date,
-            @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "a h:mm", locale = "en")
+            @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
             LocalDateTime time,
             String placeName
     ) {
@@ -35,7 +33,6 @@ public record PromisesDto(
                     promise.getId(),
                     promise.getName(),
                     dday,
-                    promise.getTime(),
                     promise.getTime(),
                     promise.getPlaceName()
             );

--- a/src/main/java/org/kkumulkkum/server/repository/PromiseRepository.java
+++ b/src/main/java/org/kkumulkkum/server/repository/PromiseRepository.java
@@ -52,4 +52,12 @@ public interface PromiseRepository extends JpaRepository<Promise, Long> {
             THEN TRUE ELSE FALSE END FROM Participant p""")
     boolean existsByArrivedAtIsNull(Long promiseId);
 
+    @Query("""
+            SELECT p FROM Participant pt
+            JOIN pt.member m
+            JOIN pt.promise p
+            WHERE p.meeting.id = :meetingId
+            AND m.user.id = :userId
+            ORDER BY p.time ASC, p.createdAt ASC""")
+    List<Promise> findPromiseByUserIdAndMeetingId(Long userId, Long meetingId);
 }

--- a/src/main/java/org/kkumulkkum/server/repository/PromiseRepository.java
+++ b/src/main/java/org/kkumulkkum/server/repository/PromiseRepository.java
@@ -60,4 +60,12 @@ public interface PromiseRepository extends JpaRepository<Promise, Long> {
             AND m.user.id = :userId
             ORDER BY p.time ASC, p.createdAt ASC""")
     List<Promise> findPromiseByUserIdAndMeetingId(Long userId, Long meetingId);
+
+    @Query("""
+            SELECT p FROM Participant pt
+            JOIN pt.member m
+            JOIN pt.promise p
+            WHERE pt.promise.id = :promiseId
+            AND m.user.id = :userId""")
+    Promise findByUserIdAndPromiseId(Long userId, Long promiseId);
 }

--- a/src/main/java/org/kkumulkkum/server/service/promise/PromiseRetriever.java
+++ b/src/main/java/org/kkumulkkum/server/service/promise/PromiseRetriever.java
@@ -73,4 +73,8 @@ public class PromiseRetriever {
     public List<Promise> findPromiseByUserIdAndMeetingId(final Long userId, final Long meetingId) {
         return promiseRepository.findPromiseByUserIdAndMeetingId(userId, meetingId);
     }
+
+    public Promise findByUserIdAndPromiseId(final Long userId, final Long promiseId) {
+        return promiseRepository.findByUserIdAndPromiseId(userId, promiseId);
+    }
 }

--- a/src/main/java/org/kkumulkkum/server/service/promise/PromiseRetriever.java
+++ b/src/main/java/org/kkumulkkum/server/service/promise/PromiseRetriever.java
@@ -68,6 +68,9 @@ public class PromiseRetriever {
 
     public boolean existsByArrivedAtIsNull(final Long promiseId) {
         return promiseRepository.existsByArrivedAtIsNull(promiseId);
+    }
 
+    public List<Promise> findPromiseByUserIdAndMeetingId(final Long userId, final Long meetingId) {
+        return promiseRepository.findPromiseByUserIdAndMeetingId(userId, meetingId);
     }
 }

--- a/src/main/java/org/kkumulkkum/server/service/promise/PromiseService.java
+++ b/src/main/java/org/kkumulkkum/server/service/promise/PromiseService.java
@@ -66,7 +66,7 @@ public class PromiseService {
                         .member(entityManager.getReference(Member.class, participantId))
                         .build()).toList()
         );
-        return PromiseDto.from(promise);
+        return PromiseDto.from(promise, true);
     }
 
     @Transactional
@@ -111,10 +111,15 @@ public class PromiseService {
 
     @Transactional(readOnly = true)
     public PromiseDto getPromise(
+            final Long userId,
             final Long promiseId
     ) {
         Promise promise = promiseRetriever.findById(promiseId);
-        return PromiseDto.from(promise);
+        Promise userPromise = promiseRetriever.findByUserIdAndPromiseId(userId, promiseId);
+
+        boolean isParticipant = userPromise != null;
+
+        return PromiseDto.from(promise, isParticipant);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/org/kkumulkkum/server/service/promise/PromiseService.java
+++ b/src/main/java/org/kkumulkkum/server/service/promise/PromiseService.java
@@ -4,10 +4,7 @@ import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import org.kkumulkkum.server.domain.*;
 import org.kkumulkkum.server.dto.promise.PromiseCreateDto;
-import org.kkumulkkum.server.dto.promise.response.MainPromiseDto;
-import org.kkumulkkum.server.dto.promise.response.MainPromisesDto;
-import org.kkumulkkum.server.dto.promise.response.PromiseDto;
-import org.kkumulkkum.server.dto.promise.response.PromisesDto;
+import org.kkumulkkum.server.dto.promise.response.*;
 import org.kkumulkkum.server.exception.PromiseException;
 import org.kkumulkkum.server.exception.code.PromiseErrorCode;
 import org.kkumulkkum.server.service.member.MemberRetreiver;
@@ -37,7 +34,7 @@ public class PromiseService {
     private final MemberRetreiver memberRetreiver;
 
     @Transactional
-    public PromiseDto createPromise(
+    public PromiseAddDto createPromise(
             final Long userId,
             final Long meetingId,
             final PromiseCreateDto createPromiseDto
@@ -66,7 +63,7 @@ public class PromiseService {
                         .member(entityManager.getReference(Member.class, participantId))
                         .build()).toList()
         );
-        return PromiseDto.from(promise, true);
+        return PromiseAddDto.from(promise);
     }
 
     @Transactional
@@ -110,7 +107,7 @@ public class PromiseService {
     }
 
     @Transactional(readOnly = true)
-    public PromiseDto getPromise(
+    public PromiseDetailDto getPromise(
             final Long userId,
             final Long promiseId
     ) {
@@ -119,7 +116,7 @@ public class PromiseService {
 
         boolean isParticipant = userPromise != null;
 
-        return PromiseDto.from(promise, isParticipant);
+        return PromiseDetailDto.from(promise, isParticipant);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/org/kkumulkkum/server/service/promise/PromiseService.java
+++ b/src/main/java/org/kkumulkkum/server/service/promise/PromiseService.java
@@ -21,6 +21,7 @@ import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -86,10 +87,25 @@ public class PromiseService {
 
     @Transactional(readOnly = true)
     public PromisesDto getPromises(
+            final Long userId,
             final Long meetingId,
-            final Boolean done
+            final Boolean done,
+            final Boolean isParticipant
     ) {
-        List<Promise> promises = promiseRetriever.findAllByMeetingId(meetingId);
+        List<Promise> allPromises = promiseRetriever.findAllByMeetingId(meetingId);
+        List<Promise> userPromises = promiseRetriever.findPromiseByUserIdAndMeetingId(userId, meetingId);
+        List<Promise> promises;
+
+        if (Boolean.TRUE.equals(isParticipant)) {
+            promises = userPromises;
+        } else if (Boolean.FALSE.equals(isParticipant)) {
+            promises = allPromises.stream()
+                    .filter(promise -> !userPromises.contains(promise))
+                    .collect(Collectors.toList());
+        } else {
+            promises = allPromises;
+        }
+
         return PromisesDto.of(promises, done);
     }
 


### PR DESCRIPTION
## Related issue 🛠
[//]: # (해당하는 이슈 번호 달아주기)
- closed #94 

## Work Description ✏️
[//]: # (작업 내용 간단 소개)
- 약속 날짜에 따라 dday에 음수와 양수가 모두 표시되도록 수정했습니다.
- 시간 형식을 "yyyy-MM-dd HH:mm:ss"로 통일했습니다.
- 특정 모임의 약속 목록 API에 promise가 사용자에게 속하는지 여부를 필터링하기 위한 isParticipant 쿼리 파라미터를 추가했습니다.
- 약속 상세 정보 조회 API에 사용자가 Promise에 참여하고 있는지 여부를 나타내는 isParticipant 필드를 추가했습니다.

## Uncompleted Tasks 😅
[//]: # (없다면 N/A)
- [ ] N/A

## To Reviewers 📢
[//]: # (reviewer가 알면 좋은 내용들)
약속 상세 정보 조회 API를 수정하면서 PromiseDto를 수정하게 되었는데, 이 Dto가 약속추가 API에도 사용되어서
약속추가 API에도 "isParticipant: true" (항상 true) 를 넣도록 명세를 수정해야할 것 같은데 어떻게 생각하시나용?
