### PR TITLE
[feat] 약속 나가기, 약속 삭제하기 API 구현

### DIFF
--- a/src/main/java/org/kkumulkkum/server/aspect/ParticipantCheckAspect.java
+++ b/src/main/java/org/kkumulkkum/server/aspect/ParticipantCheckAspect.java
@@ -5,8 +5,8 @@ import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Before;
 import org.kkumulkkum.server.annotation.IsParticipant;
-import org.kkumulkkum.server.exception.MemberException;
-import org.kkumulkkum.server.exception.code.MemberErrorCode;
+import org.kkumulkkum.server.exception.ParticipantException;
+import org.kkumulkkum.server.exception.code.ParticipantErrorCode;
 import org.kkumulkkum.server.service.participant.ParticipantRetriever;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
@@ -25,7 +25,7 @@ public class ParticipantCheckAspect {
         Long userId = (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
 
         if (!participantRetriever.existsByPromiseIdAndUserId(promiseId, userId)) {
-            throw new MemberException(MemberErrorCode.NOT_JOINED_MEMBER);
+            throw new ParticipantException(ParticipantErrorCode.NOT_JOINED_PROMISE);
         }
     }
 }

--- a/src/main/java/org/kkumulkkum/server/controller/ParticipantController.java
+++ b/src/main/java/org/kkumulkkum/server/controller/ParticipantController.java
@@ -2,6 +2,7 @@ package org.kkumulkkum.server.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.kkumulkkum.server.annotation.IsMemberByPromiseId;
+import org.kkumulkkum.server.annotation.IsParticipant;
 import org.kkumulkkum.server.annotation.UserId;
 import org.kkumulkkum.server.dto.participant.request.PreparationInfoDto;
 import org.kkumulkkum.server.dto.participant.response.LateComersDto;
@@ -76,5 +77,15 @@ public class ParticipantController {
             @PathVariable("promiseId") final Long promiseId
     ) {
         return ResponseEntity.ok().body(participantService.getLateComers(promiseId));
+    }
+
+    @IsParticipant(promiseIdParamIndex = 1)
+    @DeleteMapping("/v1/promises/{promiseId}/leave")
+    public ResponseEntity<Void> leavePromise(
+            @UserId final Long userId,
+            @PathVariable("promiseId") final Long promiseId
+    ) {
+        participantService.leavePromise(userId, promiseId);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/org/kkumulkkum/server/controller/PromiseController.java
+++ b/src/main/java/org/kkumulkkum/server/controller/PromiseController.java
@@ -72,4 +72,13 @@ public class PromiseController {
     ) {
         return ResponseEntity.ok().body(promiseService.getUpcomingPromises(userId));
     }
+
+    @IsParticipant(promiseIdParamIndex = 0)
+    @DeleteMapping("/v1/promises/{promiseId}")
+    public ResponseEntity<Void> deletePromise(
+            @PathVariable("promiseId") final Long promiseId
+    ) {
+        promiseService.deletePromise(promiseId);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/org/kkumulkkum/server/service/participant/ParticipantRemover.java
+++ b/src/main/java/org/kkumulkkum/server/service/participant/ParticipantRemover.java
@@ -1,8 +1,11 @@
 package org.kkumulkkum.server.service.participant;
 
 import lombok.RequiredArgsConstructor;
+import org.kkumulkkum.server.domain.Participant;
 import org.kkumulkkum.server.repository.ParticipantRepository;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
 
 @Component
 @RequiredArgsConstructor
@@ -16,5 +19,9 @@ public class ParticipantRemover {
 
     public void deleteById(final Long id) {
         participantRepository.deleteById(id);
+    }
+
+    public void deleteAll(List<Participant> participants) {
+        participantRepository.deleteAllInBatch(participants);
     }
 }

--- a/src/main/java/org/kkumulkkum/server/service/participant/ParticipantRemover.java
+++ b/src/main/java/org/kkumulkkum/server/service/participant/ParticipantRemover.java
@@ -13,4 +13,8 @@ public class ParticipantRemover {
     public void deleteByMemberId(final Long memberId) {
         participantRepository.deleteByMemberId(memberId);
     }
+
+    public void deleteById(final Long id) {
+        participantRepository.deleteById(id);
+    }
 }

--- a/src/main/java/org/kkumulkkum/server/service/participant/ParticipantService.java
+++ b/src/main/java/org/kkumulkkum/server/service/participant/ParticipantService.java
@@ -30,6 +30,7 @@ public class ParticipantService {
     private final ParticipantRetriever participantRetriever;
     private final ParticipantEditor participantEditor;
     private final PromiseRetriever promiseRetriever;
+    private final ParticipantRemover participantRemover;
     private final FcmService fcmService;
 
     @Transactional
@@ -136,6 +137,15 @@ public class ParticipantService {
                         )
                         .collect(Collectors.toList())
         );
+    }
+
+    @Transactional
+    public void leavePromise(
+            final Long userId,
+            final Long promiseId
+    ) {
+        Participant participant = participantRetriever.findByPromiseIdAndUserId(promiseId, userId);
+        participantRemover.deleteById(participant.getId());
     }
 
     private boolean validateState(

--- a/src/main/java/org/kkumulkkum/server/service/promise/PromiseRemover.java
+++ b/src/main/java/org/kkumulkkum/server/service/promise/PromiseRemover.java
@@ -1,0 +1,16 @@
+package org.kkumulkkum.server.service.promise;
+
+import lombok.RequiredArgsConstructor;
+import org.kkumulkkum.server.repository.PromiseRepository;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PromiseRemover {
+
+    private final PromiseRepository promiseRepository;
+
+    public void deleteById(final Long promiseId) {
+        promiseRepository.deleteById(promiseId);
+    }
+}

--- a/src/main/java/org/kkumulkkum/server/service/promise/PromiseService.java
+++ b/src/main/java/org/kkumulkkum/server/service/promise/PromiseService.java
@@ -8,6 +8,7 @@ import org.kkumulkkum.server.dto.promise.response.*;
 import org.kkumulkkum.server.exception.PromiseException;
 import org.kkumulkkum.server.exception.code.PromiseErrorCode;
 import org.kkumulkkum.server.service.member.MemberRetreiver;
+import org.kkumulkkum.server.service.participant.ParticipantRemover;
 import org.kkumulkkum.server.service.participant.ParticipantRetriever;
 import org.kkumulkkum.server.service.participant.ParticipantSaver;
 import org.kkumulkkum.server.service.userInfo.UserInfoRetriever;
@@ -32,6 +33,8 @@ public class PromiseService {
     private final UserInfoRetriever userInfoRetriever;
     private final EntityManager entityManager;
     private final MemberRetreiver memberRetreiver;
+    private final PromiseRemover promiseRemover;
+    private final ParticipantRemover participantRemover;
 
     @Transactional
     public PromiseAddDto createPromise(
@@ -142,6 +145,18 @@ public class PromiseService {
             );
         }
         return MainPromisesDto.from(promiseRetriever.findUpcomingPromises(userId, 4));
+    }
+
+    @Transactional
+    public void deletePromise(final Long promiseId) {
+        Promise promise = promiseRetriever.findById(promiseId);
+
+        List<Participant> participants = participantRetriever.findAllByPromiseId(promise.getId());
+        // 약속에 속한 모든 참가자 삭제
+        participantRemover.deleteAll(participants);
+
+        // 약속 삭제
+        promiseRemover.deleteById(promise.getId());
     }
 
     private void updateUserInfo(


### PR DESCRIPTION
## Related issue 🛠
[//]: # (해당하는 이슈 번호 달아주기)
- closed #96

## Work Description ✏️
[//]: # (작업 내용 간단 소개)
- 약속 나가기 API 구현
- 약속 삭제하기 API 구현
- @IsParticipant 어노테이션 사용 시 ParticipantCheckAspect에서, 해당 유저가 참가자가 아닐 때 반환하는 오류를 '모임에 참여하지 않은 회원입니다' 에서 '참여하지 않은 약속입니다'로 변경

## Uncompleted Tasks 😅
[//]: # (없다면 N/A)
- [ ] N/A

## To Reviewers 📢
[//]: # (reviewer가 알면 좋은 내용들)
약속한 속한 모든 참가자들을 삭제할 때 `deleteAll`과는 다르게 단일 쿼리를 보내 성능이 향상된다는 `deleteAllInBatch`를 사용해보았습니다..!  그러나 `deleteAllInBatch`가 영속성 컨텍스트 관련 처리는 생략한다고 한다고 해서 적절한 선택을 한건지 고민이 됩니다.