### PR TITLE
[fix] 약속 수정 API 관련 수정 

### DIFF
--- a/src/main/java/org/kkumulkkum/server/domain/Promise.java
+++ b/src/main/java/org/kkumulkkum/server/domain/Promise.java
@@ -80,6 +80,7 @@ public class Promise extends BaseTimeEntity {
             Double y,
             String address,
             String roadAddress,
+            LocalDateTime time,
             DressUpLevel dressUpLevel,
             String penalty) {
         this.name = name;
@@ -88,6 +89,7 @@ public class Promise extends BaseTimeEntity {
         this.y = y;
         this.address = address;
         this.roadAddress = roadAddress;
+        this.time = time;
         this.dressUpLevel = dressUpLevel;
         this.penalty = penalty;
     }

--- a/src/main/java/org/kkumulkkum/server/dto/promise/response/PromiseDetailDto.java
+++ b/src/main/java/org/kkumulkkum/server/dto/promise/response/PromiseDetailDto.java
@@ -10,6 +10,8 @@ public record PromiseDetailDto(
         Long promiseId,
         String promiseName,
         String placeName,
+        Double x,
+        Double y,
         String address,
         String roadAddress,
         @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
@@ -23,6 +25,8 @@ public record PromiseDetailDto(
                 promise.getId(),
                 promise.getName(),
                 promise.getPlaceName(),
+                promise.getX(),
+                promise.getY(),
                 promise.getAddress(),
                 promise.getRoadAddress(),
                 promise.getTime(),

--- a/src/main/java/org/kkumulkkum/server/service/promise/PromiseEditor.java
+++ b/src/main/java/org/kkumulkkum/server/service/promise/PromiseEditor.java
@@ -22,6 +22,7 @@ public class PromiseEditor {
                 updatePromiseDto.y(),
                 updatePromiseDto.address(),
                 updatePromiseDto.roadAddress(),
+                updatePromiseDto.time(),
                 updatePromiseDto.dressUpLevel(),
                 updatePromiseDto.penalty()
         );


### PR DESCRIPTION
## Related issue 🛠
[//]: # (해당하는 이슈 번호 달아주기)
- closed #104 
## Work Description ✏️
[//]: # (작업 내용 간단 소개)
- 약속 수정 시, 장소 변경이 없는 경우를 대비하여 약속 상세 정보에 x, y 좌표를 추가해주었습니다.
- 약속 수정시 time도 수정될 수 있도록 수정했습니다.

## Uncompleted Tasks 😅
[//]: # (없다면 N/A)
- [ ] N/A

## To Reviewers 📢
[//]: # (reviewer가 알면 좋은 내용들)