### PR TITLE
[fix] 애플 회원탈퇴 시 authCode 입력 값 확인 로직 추가

### DIFF
--- a/src/main/java/org/kkumulkkum/server/auth/openfeign/apple/service/AppleService.java
+++ b/src/main/java/org/kkumulkkum/server/auth/openfeign/apple/service/AppleService.java
@@ -44,6 +44,9 @@ public class AppleService {
     }
 
     public void revoke(final String authCode) {
+        if (authCode == null || authCode.isEmpty()) {
+            throw new AuthException(AuthErrorCode.INVALID_AUTH_CODE);
+        }
         try {
             String clientSecret = appleClientSecretGenerator.createClientSecret();
             String refreshToken = getRefreshToken(authCode, clientSecret);

--- a/src/main/java/org/kkumulkkum/server/auth/openfeign/apple/service/AppleService.java
+++ b/src/main/java/org/kkumulkkum/server/auth/openfeign/apple/service/AppleService.java
@@ -57,7 +57,7 @@ public class AppleService {
                     "refresh_token"
             );
         } catch (Exception e){
-            log.error("apple revoke failed : {}", e.getMessage());
+            log.error("apple revoke failed : {}", e.getMessage(), e);
             throw new AuthException(AuthErrorCode.APPLE_REVOKE_FAILED);
         }
     }
@@ -72,7 +72,7 @@ public class AppleService {
             );
             return appleTokenDto.refreshToken();
         } catch (Exception e){
-            log.error("apple token request failed : {}", e.getMessage());
+            log.error("apple token request failed : {}", e.getMessage(), e);
             throw new AuthException(AuthErrorCode.APPLE_TOKEN_REQUEST_FAILED);
         }
     }

--- a/src/main/java/org/kkumulkkum/server/auth/openfeign/apple/service/AppleService.java
+++ b/src/main/java/org/kkumulkkum/server/auth/openfeign/apple/service/AppleService.java
@@ -11,9 +11,12 @@ import org.kkumulkkum.server.auth.openfeign.apple.verify.AppleJwtParser;
 import org.kkumulkkum.server.auth.openfeign.apple.verify.PublicKeyGenerator;
 import org.kkumulkkum.server.auth.openfeign.kakao.dto.SocialUserDto;
 import org.kkumulkkum.server.exception.AuthException;
+import org.kkumulkkum.server.exception.BusinessException;
 import org.kkumulkkum.server.exception.code.AuthErrorCode;
+import org.kkumulkkum.server.exception.code.BusinessErrorCode;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.web.bind.MissingRequestHeaderException;
 
 import java.security.PublicKey;
 import java.util.Map;
@@ -45,7 +48,7 @@ public class AppleService {
 
     public void revoke(final String authCode) {
         if (authCode == null || authCode.isEmpty()) {
-            throw new AuthException(AuthErrorCode.INVALID_AUTH_CODE);
+            throw new BusinessException(BusinessErrorCode.MISSING_REQUIRED_HEADER);
         }
         try {
             String clientSecret = appleClientSecretGenerator.createClientSecret();

--- a/src/main/java/org/kkumulkkum/server/exception/code/AuthErrorCode.java
+++ b/src/main/java/org/kkumulkkum/server/exception/code/AuthErrorCode.java
@@ -15,7 +15,6 @@ public enum AuthErrorCode implements DefaultErrorCode {
     EXPIRED_APPLE_IDENTITY_TOKEN(HttpStatus.BAD_REQUEST, 40014, "Apple Identity Token 유효기간이 만료됐습니다."),
     APPLE_REVOKE_FAILED(HttpStatus.BAD_REQUEST, 40015,"Apple 회원 탈퇴에 실패했습니다."),
     APPLE_TOKEN_REQUEST_FAILED(HttpStatus.BAD_REQUEST, 40016, "Apple 토큰 요청에 실패했습니다."),
-    INVALID_AUTH_CODE(HttpStatus.BAD_REQUEST, 40017, "Apple authCode값이 비어있습니다."),
     // 401 UNAUTHORIZED
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, 40110, "인증되지 않은 사용자입니다."),
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, 40111, "올바르지 않은 토큰입니다."),

--- a/src/main/java/org/kkumulkkum/server/exception/code/AuthErrorCode.java
+++ b/src/main/java/org/kkumulkkum/server/exception/code/AuthErrorCode.java
@@ -15,6 +15,7 @@ public enum AuthErrorCode implements DefaultErrorCode {
     EXPIRED_APPLE_IDENTITY_TOKEN(HttpStatus.BAD_REQUEST, 40014, "Apple Identity Token 유효기간이 만료됐습니다."),
     APPLE_REVOKE_FAILED(HttpStatus.BAD_REQUEST, 40015,"Apple 회원 탈퇴에 실패했습니다."),
     APPLE_TOKEN_REQUEST_FAILED(HttpStatus.BAD_REQUEST, 40016, "Apple 토큰 요청에 실패했습니다."),
+    INVALID_AUTH_CODE(HttpStatus.BAD_REQUEST, 40017, "Apple authCode값이 비어있습니다."),
     // 401 UNAUTHORIZED
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, 40110, "인증되지 않은 사용자입니다."),
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, 40111, "올바르지 않은 토큰입니다."),


### PR DESCRIPTION
## Related issue 🛠
[//]: # (해당하는 이슈 번호 달아주기)
- closed #106 
## Work Description ✏️
[//]: # (작업 내용 간단 소개)
- 애플 회원탈퇴 시 authCode 입력 값을 확인하여 authCode가 비어있으면 400에러를 내도록 했습니다.
- 예외 객체 전체를 로그에 기록할 수 있도록 수정했습니다.

## Uncompleted Tasks 😅
[//]: # (없다면 N/A)
- [ ] N/A

## To Reviewers 📢
[//]: # (reviewer가 알면 좋은 내용들)