### PR TITLE
[fix] 약속 나가기 시 약속 참여 인원에 따른 약속 삭제 

### DIFF
--- a/src/main/java/org/kkumulkkum/server/service/participant/ParticipantService.java
+++ b/src/main/java/org/kkumulkkum/server/service/participant/ParticipantService.java
@@ -15,6 +15,7 @@ import org.kkumulkkum.server.external.FcmService;
 import org.kkumulkkum.server.external.dto.FcmMessageDto;
 import org.kkumulkkum.server.external.enums.FcmContent;
 import org.kkumulkkum.server.service.member.MemberRetreiver;
+import org.kkumulkkum.server.service.promise.PromiseRemover;
 import org.kkumulkkum.server.service.promise.PromiseRetriever;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -35,6 +36,7 @@ public class ParticipantService {
     private final PromiseRetriever promiseRetriever;
     private final MemberRetreiver memberRetreiver;
     private final ParticipantRemover participantRemover;
+    private final PromiseRemover promiseRemover;
     private final FcmService fcmService;
 
     @Transactional
@@ -169,6 +171,11 @@ public class ParticipantService {
     ) {
         Participant participant = participantRetriever.findByPromiseIdAndUserId(promiseId, userId);
         participantRemover.deleteById(participant.getId());
+
+        List<Participant> remainingParticipants = participantRetriever.findAllByPromiseId(promiseId);
+        if(remainingParticipants.isEmpty()) {
+            promiseRemover.deleteById(promiseId);
+        }
     }
 
     private boolean validateState(


### PR DESCRIPTION
## Related issue 🛠
[//]: # (해당하는 이슈 번호 달아주기)
- closed #117 

## Work Description ✏️
[//]: # (작업 내용 간단 소개)
- 약속 나가기 시, 약속 참가자가 아무도 없게되면 약속 자체를 삭제하도록 수정했습니다.

## Uncompleted Tasks 😅
[//]: # (없다면 N/A)
- [ ] N/A

## To Reviewers 📢
[//]: # (reviewer가 알면 좋은 내용들)