### PR TITLE
[fix] 디스코드 로깅 오류 해결

### DIFF
--- a/src/main/java/org/kkumulkkum/server/log/discord/DiscordAppender.java
+++ b/src/main/java/org/kkumulkkum/server/log/discord/DiscordAppender.java
@@ -34,7 +34,6 @@ public class DiscordAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
         } else if (level.equals("ERROR")) {
             return Color.red;
         }
-
         return Color.blue;
     }
 

--- a/src/main/java/org/kkumulkkum/server/log/discord/DiscordAppender.java
+++ b/src/main/java/org/kkumulkkum/server/log/discord/DiscordAppender.java
@@ -50,7 +50,7 @@ public class DiscordAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
         IThrowableProxy throwable = eventObject.getThrowableProxy();
 
         if (throwable != null) {
-            exceptionBrief = throwable.getClassName() + ": " + throwable.getMessage();
+            exceptionBrief = throwable.getClassName() + ": " + throwable.getMessage().replaceAll("\"", "'");
         }
 
         if (exceptionBrief.equals("")) {

--- a/src/main/java/org/kkumulkkum/server/log/discord/DiscordAppender.java
+++ b/src/main/java/org/kkumulkkum/server/log/discord/DiscordAppender.java
@@ -46,14 +46,13 @@ public class DiscordAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
 
         String level = eventObject.getLevel().levelStr;
         String exceptionBrief = "";
-        String exceptionDetail = "";
         IThrowableProxy throwable = eventObject.getThrowableProxy();
 
         if (throwable != null) {
             exceptionBrief = throwable.getClassName() + ": " + throwable.getMessage().replaceAll("\"", "'");
         }
 
-        if (exceptionBrief.equals("")) {
+        if (exceptionBrief.isEmpty()) {
             exceptionBrief = "EXCEPTION 정보가 남지 않았습니다.";
         }
 
@@ -99,7 +98,7 @@ public class DiscordAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
         );
 
         if (throwable != null) {
-            exceptionDetail = ThrowableProxyUtil.asString(throwable);
+            String exceptionDetail = ThrowableProxyUtil.asString(throwable);
             String exception = exceptionDetail.substring(0, 4000);
             discordWebhook.addEmbed(
                     new EmbedObject()


### PR DESCRIPTION
## Related issue 🛠
[//]: # (해당하는 이슈 번호 달아주기)
- closed #127 

## Work Description ✏️
[//]: # (작업 내용 간단 소개)
- 일부 예외가 디스코드 메시지로 날라오지 않아 이를 해결했습니다.
- 해당 예외들은 다음과 같이 생겼습니다.
<img width="1199" alt="스크린샷 2024-09-05 01 04 26" src="https://github.com/user-attachments/assets/9780adc6-f236-43c1-a7ed-812f976047fd">
<img width="1202" alt="스크린샷 2024-09-05 01 04 45" src="https://github.com/user-attachments/assets/90325505-a991-44b2-8d19-a2c24e15b376">
- 디버깅 결과 해당 예외 메시지에 String 값을 포함할 경우 String 값을 표현할 때 사용되는 "가 Json을 invalid하게 만들기 때문에 일어난 일임을 확인했습니다.
- 이 때문에 discord 웹훅 API가 요청을 날릴 때 400 에러가 떠서 일어난 문제입니다.
- 이를 방지하기 위해 replaceAll로 "를 '로 변경해주었습니다.

## Uncompleted Tasks 😅
[//]: # (없다면 N/A)
- [ ] N/A

## To Reviewers 📢
[//]: # (reviewer가 알면 좋은 내용들)
세상엔 예상치 못한 일들이 참 많군요...