### PR TITLE
[fix] HttpMessageNotReadableException 핸들링 추가

### DIFF
--- a/src/main/java/org/kkumulkkum/server/advice/GlobalExceptionHandler.java
+++ b/src/main/java/org/kkumulkkum/server/advice/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.kkumulkkum.server.exception.*;
 import org.kkumulkkum.server.exception.code.*;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingRequestHeaderException;
@@ -109,7 +110,11 @@ public class GlobalExceptionHandler {
                 .body(BusinessErrorCode.METHOD_NOT_ALLOWED);
     }
 
-    @ExceptionHandler(value = {HandlerMethodValidationException.class, MethodArgumentNotValidException.class})
+    @ExceptionHandler(value = {
+            HandlerMethodValidationException.class,
+            MethodArgumentNotValidException.class,
+            HttpMessageNotReadableException.class
+    })
     public ResponseEntity<BusinessErrorCode> handleValidationException(Exception e) {
         log.warn("GlobalExceptionHandler catch MethodArgumentNotValidException : {}", e.getMessage());
         return ResponseEntity


### PR DESCRIPTION
## Related issue 🛠
[//]: # (해당하는 이슈 번호 달아주기)
- closed #144

## Work Description ✏️
[//]: # (작업 내용 간단 소개)
- 핸들링되고 있지 않던 HttpMessageNotReadableException을 GlobalExceptionHandler에서 처리하도록 추가했습니다.

## Uncompleted Tasks 😅
[//]: # (없다면 N/A)
- [ ] N/A

## To Reviewers 📢
[//]: # (reviewer가 알면 좋은 내용들)