### PR TITLE
[fix] FCM deprecated method 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,7 +69,7 @@ dependencies {
 	implementation("software.amazon.awssdk:s3:2.21.0")
 
 	// Firebase
-	implementation 'com.google.firebase:firebase-admin:9.2.0'
+	implementation 'com.google.firebase:firebase-admin:9.3.0'
 
 	// Logback Discord Appender
 	implementation('com.github.napstr:logback-discord-appender:1.0.0')

--- a/src/main/java/org/kkumulkkum/server/external/FcmService.java
+++ b/src/main/java/org/kkumulkkum/server/external/FcmService.java
@@ -26,7 +26,7 @@ public class FcmService {
     ){
         MulticastMessage message = createBulkMessage(fcmTokens, fcmMessageDto);
         try {
-            FirebaseMessaging.getInstance().sendMulticast(message);
+            FirebaseMessaging.getInstance().sendEachForMulticast(message);
         } catch (FirebaseMessagingException e){
             throw new FirebaseException(FirebaseErrorCode.FCM_ERROR);
         }


### PR DESCRIPTION
## Related issue 🛠
[//]: # (해당하는 이슈 번호 달아주기)
- closed #146

## Work Description ✏️
[//]: # (작업 내용 간단 소개)
- 기존에 사용하고 있었던 sendMulticast 메소드가 deprecated되어 sendEachForMulticast로 바꿔주었습니다.
[참고링크](https://stackoverflow.com/questions/78947756/no-enum-constant-com-google-firebase-errorcode-unimplemented)

## Uncompleted Tasks 😅
[//]: # (없다면 N/A)
- [ ] N/A

## To Reviewers 📢
[//]: # (reviewer가 알면 좋은 내용들)