### PR TITLE
[fix] 회원탈퇴 시 혼자 만든 약속 삭제하도록 수정

### DIFF
--- a/src/main/java/org/kkumulkkum/server/repository/MemberRepository.java
+++ b/src/main/java/org/kkumulkkum/server/repository/MemberRepository.java
@@ -37,7 +37,7 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     @Query("""
             SELECT m from Member m
-            join fetch m.meeting
+            JOIN FETCH m.meeting
             WHERE m.user.id = :userId
             """)
     List<Member> findByUserId(Long userId);

--- a/src/main/java/org/kkumulkkum/server/repository/MemberRepository.java
+++ b/src/main/java/org/kkumulkkum/server/repository/MemberRepository.java
@@ -35,6 +35,11 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Member findByMeetingIdAndUserId(Long meetingId, Long userId);
 
+    @Query("""
+            SELECT m from Member m
+            join fetch m.meeting
+            WHERE m.user.id = :userId
+            """)
     List<Member> findByUserId(Long userId);
 
     @Query("""

--- a/src/main/java/org/kkumulkkum/server/service/auth/AuthService.java
+++ b/src/main/java/org/kkumulkkum/server/service/auth/AuthService.java
@@ -19,6 +19,9 @@ import org.kkumulkkum.server.exception.code.AuthErrorCode;
 import org.kkumulkkum.server.service.member.MemberRemover;
 import org.kkumulkkum.server.service.member.MemberRetreiver;
 import org.kkumulkkum.server.service.participant.ParticipantRemover;
+import org.kkumulkkum.server.service.participant.ParticipantRetriever;
+import org.kkumulkkum.server.service.promise.PromiseRemover;
+import org.kkumulkkum.server.service.promise.PromiseRetriever;
 import org.kkumulkkum.server.service.user.UserRemover;
 import org.kkumulkkum.server.service.user.UserRetriever;
 import org.kkumulkkum.server.service.user.UserSaver;
@@ -45,6 +48,9 @@ public class AuthService {
     private final TokenRemover tokenRemover;
     private final UserInfoRetriever userInfoRetriever;
     private final MemberRetreiver memberRetreiver;
+    private final PromiseRetriever promiseRetriever;
+    private final ParticipantRetriever participantRetriever;
+    private final PromiseRemover promiseRemover;
     private final ParticipantRemover participantRemover;
     private final MemberRemover memberRemover;
     private final UserInfoRemover userInfoRemover;
@@ -148,6 +154,7 @@ public class AuthService {
         // 각 Member에 대한 Participant 삭제
         for(Member member : members) {
            participantRemover.deleteByMemberId(member.getId());
+           removeEmptyPromises(member.getMeeting().getId());
         }
 
         // Member 데이터 삭제
@@ -157,5 +164,11 @@ public class AuthService {
         userInfoRemover.deleteByUserId(user.getId());
         // User 삭제
         userRemover.delete(user);
+    }
+
+    private void removeEmptyPromises(final Long meetingId) {
+        promiseRetriever.findAllByMeetingId(meetingId).stream()
+                .filter(promise -> participantRetriever.findAllByPromiseId(promise.getId()).isEmpty())
+                .forEach(promise -> promiseRemover.deleteById(promise.getId()));
     }
 }


### PR DESCRIPTION
## Related issue 🛠
[//]: # (해당하는 이슈 번호 달아주기)
- closed #148

## Work Description ✏️
[//]: # (작업 내용 간단 소개)
- 혼자 약속을 만들고 회원 탈퇴 시, 참여자가 없어 삭제할 수 없는 약속이 생기는 것을 방지하기 위해 회원 탈퇴 시에 혼자 만든 약속이 삭제되도록 했습니다.
- fetch join 사용했습니당

## Uncompleted Tasks 😅
[//]: # (없다면 N/A)
- [ ] N/A

## To Reviewers 📢
[//]: # (reviewer가 알면 좋은 내용들)