### PR TITLE
[refactor] 특정 모임 약속 목록 반환 querydsl 변환 

### DIFF
--- a/src/main/java/org/kkumulkkum/server/api/promise/dto/response/PromisesDto.java
+++ b/src/main/java/org/kkumulkkum/server/api/promise/dto/response/PromisesDto.java
@@ -10,10 +10,9 @@ import java.util.List;
 public record PromisesDto(
         List<PromiseDto> promises
 ) {
-    public static PromisesDto of(List<Promise> promises, Boolean done) {
+    public static PromisesDto of(List<Promise> promises) {
         return new PromisesDto(
                 promises.stream()
-                        .filter(promise -> done == null || done.equals(promise.isCompleted()))
                         .map(PromisesDto.PromiseDto::from)
                         .toList()
         );

--- a/src/main/java/org/kkumulkkum/server/api/promise/service/PromiseService.java
+++ b/src/main/java/org/kkumulkkum/server/api/promise/service/PromiseService.java
@@ -100,20 +100,6 @@ public class PromiseService {
             final Boolean done,
             final Boolean isParticipant
     ) {
-//        List<Promise> allPromises = promiseRetriever.findAllByMeetingId(meetingId);
-//        List<Promise> userPromises = promiseRetriever.findPromiseByUserIdAndMeetingId(userId, meetingId);
-//        List<Promise> promises;
-//
-//        if (Boolean.TRUE.equals(isParticipant)) {
-//            promises = userPromises;
-//        } else if (Boolean.FALSE.equals(isParticipant)) {
-//            promises = allPromises.stream()
-//                    .filter(promise -> !userPromises.contains(promise))
-//                    .collect(Collectors.toList());
-//        } else {
-//            promises = allPromises;
-//        }
-
         List<Promise> promises = promiseRetriever.findPromisesByConditions(userId, meetingId, done, isParticipant);
 
         return PromisesDto.of(promises);

--- a/src/main/java/org/kkumulkkum/server/api/promise/service/PromiseService.java
+++ b/src/main/java/org/kkumulkkum/server/api/promise/service/PromiseService.java
@@ -100,21 +100,23 @@ public class PromiseService {
             final Boolean done,
             final Boolean isParticipant
     ) {
-        List<Promise> allPromises = promiseRetriever.findAllByMeetingId(meetingId);
-        List<Promise> userPromises = promiseRetriever.findPromiseByUserIdAndMeetingId(userId, meetingId);
-        List<Promise> promises;
+//        List<Promise> allPromises = promiseRetriever.findAllByMeetingId(meetingId);
+//        List<Promise> userPromises = promiseRetriever.findPromiseByUserIdAndMeetingId(userId, meetingId);
+//        List<Promise> promises;
+//
+//        if (Boolean.TRUE.equals(isParticipant)) {
+//            promises = userPromises;
+//        } else if (Boolean.FALSE.equals(isParticipant)) {
+//            promises = allPromises.stream()
+//                    .filter(promise -> !userPromises.contains(promise))
+//                    .collect(Collectors.toList());
+//        } else {
+//            promises = allPromises;
+//        }
 
-        if (Boolean.TRUE.equals(isParticipant)) {
-            promises = userPromises;
-        } else if (Boolean.FALSE.equals(isParticipant)) {
-            promises = allPromises.stream()
-                    .filter(promise -> !userPromises.contains(promise))
-                    .collect(Collectors.toList());
-        } else {
-            promises = allPromises;
-        }
+        List<Promise> promises = promiseRetriever.findPromisesByConditions(userId, meetingId, done, isParticipant);
 
-        return PromisesDto.of(promises, done);
+        return PromisesDto.of(promises);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/org/kkumulkkum/server/domain/promise/Promise.java
+++ b/src/main/java/org/kkumulkkum/server/domain/promise/Promise.java
@@ -7,8 +7,10 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.kkumulkkum.server.domain.base.BaseTimeEntity;
 import org.kkumulkkum.server.domain.meeting.Meeting;
+import org.kkumulkkum.server.domain.participant.Participant;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Entity
 @Getter
@@ -43,6 +45,9 @@ public class Promise extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "meeting_id")
     private Meeting meeting;
+
+    @OneToMany(mappedBy = "promise")
+    private List<Participant> participants;
 
     @Builder
     public Promise(

--- a/src/main/java/org/kkumulkkum/server/domain/promise/manager/PromiseRetriever.java
+++ b/src/main/java/org/kkumulkkum/server/domain/promise/manager/PromiseRetriever.java
@@ -70,10 +70,6 @@ public class PromiseRetriever {
         return promiseRepository.existsByArrivedAtIsNull(promiseId);
     }
 
-    public List<Promise> findPromiseByUserIdAndMeetingId(final Long userId, final Long meetingId) {
-        return promiseRepository.findPromiseByUserIdAndMeetingId(userId, meetingId);
-    }
-
     public Promise findByUserIdAndPromiseId(final Long userId, final Long promiseId) {
         return promiseRepository.findByUserIdAndPromiseId(userId, promiseId);
     }

--- a/src/main/java/org/kkumulkkum/server/domain/promise/manager/PromiseRetriever.java
+++ b/src/main/java/org/kkumulkkum/server/domain/promise/manager/PromiseRetriever.java
@@ -77,4 +77,8 @@ public class PromiseRetriever {
     public Promise findByUserIdAndPromiseId(final Long userId, final Long promiseId) {
         return promiseRepository.findByUserIdAndPromiseId(userId, promiseId);
     }
+
+    public List<Promise> findPromisesByConditions(final Long userId, final Long meetingId, final Boolean done, final Boolean isParticipant) {
+        return promiseRepository.findPromiseByConditions(userId, meetingId, done, isParticipant);
+    }
 }

--- a/src/main/java/org/kkumulkkum/server/domain/promise/repository/PromiseRepository.java
+++ b/src/main/java/org/kkumulkkum/server/domain/promise/repository/PromiseRepository.java
@@ -57,15 +57,6 @@ public interface PromiseRepository extends JpaRepository<Promise, Long>, Promise
             SELECT p FROM Participant pt
             JOIN pt.member m
             JOIN pt.promise p
-            WHERE p.meeting.id = :meetingId
-            AND m.user.id = :userId
-            ORDER BY p.time ASC, p.createdAt ASC""")
-    List<Promise> findPromiseByUserIdAndMeetingId(Long userId, Long meetingId);
-
-    @Query("""
-            SELECT p FROM Participant pt
-            JOIN pt.member m
-            JOIN pt.promise p
             WHERE pt.promise.id = :promiseId
             AND m.user.id = :userId""")
     Promise findByUserIdAndPromiseId(Long userId, Long promiseId);

--- a/src/main/java/org/kkumulkkum/server/domain/promise/repository/PromiseRepository.java
+++ b/src/main/java/org/kkumulkkum/server/domain/promise/repository/PromiseRepository.java
@@ -1,6 +1,7 @@
 package org.kkumulkkum.server.domain.promise.repository;
 
 import org.kkumulkkum.server.domain.promise.Promise;
+import org.kkumulkkum.server.domain.promise.repository.custom.PromiseRepositoryCustom;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,7 +10,7 @@ import org.springframework.data.jpa.repository.Query;
 import java.time.LocalDateTime;
 import java.util.List;
 
-public interface PromiseRepository extends JpaRepository<Promise, Long> {
+public interface PromiseRepository extends JpaRepository<Promise, Long>, PromiseRepositoryCustom {
 
     List<Promise> findAllByMeetingIdOrderByTimeAscCreatedAtAsc(Long meetingId);
 

--- a/src/main/java/org/kkumulkkum/server/domain/promise/repository/custom/PromiseRepositoryCustom.java
+++ b/src/main/java/org/kkumulkkum/server/domain/promise/repository/custom/PromiseRepositoryCustom.java
@@ -1,0 +1,9 @@
+package org.kkumulkkum.server.domain.promise.repository.custom;
+
+import org.kkumulkkum.server.domain.promise.Promise;
+
+import java.util.List;
+
+public interface PromiseRepositoryCustom {
+    List<Promise> findPromiseByConditions(Long userId, Long meetingId, Boolean done, Boolean isParticipant);
+}

--- a/src/main/java/org/kkumulkkum/server/domain/promise/repository/custom/PromiseRepositoryCustomImpl.java
+++ b/src/main/java/org/kkumulkkum/server/domain/promise/repository/custom/PromiseRepositoryCustomImpl.java
@@ -23,8 +23,8 @@ public class PromiseRepositoryCustomImpl implements PromiseRepositoryCustom {
     public List<Promise> findPromiseByConditions(Long userId, Long meetingId, Boolean done, Boolean isParticipant) {
         return queryFactory
                 .selectFrom(promise)
-                .join(promise.participants, participant).fetchJoin()
-                .join(participant.member, member).fetchJoin()
+                .leftJoin(promise.participants, participant).fetchJoin()
+                .leftJoin(participant.member, member).fetchJoin()
                 .where(
                         meetingIdEq(meetingId),
                         isParticipantEq(userId, meetingId, isParticipant),

--- a/src/main/java/org/kkumulkkum/server/domain/promise/repository/custom/PromiseRepositoryCustomImpl.java
+++ b/src/main/java/org/kkumulkkum/server/domain/promise/repository/custom/PromiseRepositoryCustomImpl.java
@@ -1,0 +1,69 @@
+package org.kkumulkkum.server.domain.promise.repository.custom;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.kkumulkkum.server.domain.promise.Promise;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static org.kkumulkkum.server.domain.member.QMember.member;
+import static org.kkumulkkum.server.domain.participant.QParticipant.participant;
+import static org.kkumulkkum.server.domain.promise.QPromise.promise;
+
+@Repository
+@RequiredArgsConstructor
+public class PromiseRepositoryCustomImpl implements PromiseRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<Promise> findPromiseByConditions(Long userId, Long meetingId, Boolean done, Boolean isParticipant) {
+        return queryFactory
+                .selectFrom(promise)
+                .join(promise.participants, participant).fetchJoin()
+                .join(participant.member, member).fetchJoin()
+                .where(
+                        meetingIdEq(meetingId),
+                        isParticipantEq(userId, meetingId, isParticipant),
+                        doneEq(done)
+                )
+                .orderBy(promise.time.asc(), promise.createdAt.asc())
+                .fetch();
+    }
+
+    private BooleanExpression meetingIdEq(Long meetingId) {
+        return meetingId != null ? promise.meeting.id.eq(meetingId) : null;
+    }
+
+    private BooleanExpression isParticipantEq(Long userId, Long meetingId, Boolean isParticipant) {
+        if (isParticipant == null) return null;
+
+        if (isParticipant) {
+            return promise.id.in(
+                    JPAExpressions.select(participant.promise.id)
+                            .from(participant)
+                            .join(participant.member, member)
+                            .where(member.user.id.eq(userId),
+                                    participant.promise.meeting.id.eq(meetingId)
+                            )
+            );
+        } else {
+            return promise.id.notIn(
+                    JPAExpressions.select(participant.promise.id)
+                            .from(participant)
+                            .join(participant.member, member)
+                            .where(member.user.id.eq(userId),
+                                    participant.promise.meeting.id.eq(meetingId)
+                            )
+            );
+        }
+    }
+
+    private BooleanExpression doneEq(Boolean done) {
+        return done != null ? promise.isCompleted.eq(done) : null;
+    }
+
+}


### PR DESCRIPTION
## Related issue 🛠
[//]: # (해당하는 이슈 번호 달아주기)
- closed #157

## Work Description ✏️
[//]: # (작업 내용 간단 소개)
기존 약속 조회 로직은 모든 약속을 조회하는 findAllByMeetingId(meetingId)와 사용자가 참여한 약속을 조회하는 findPromiseByUserIdAndMeetingId(userId, meetingId) 두 개의 쿼리를 실행한 후, Java Stream을 활용해 리스트를 필터링하는 방식이었습니다. 
이로 인해 불필요한 쿼리가 두 번 실행되는 문제점이 있었습니다.
이를 하나의 쿼리로 수행할 수 있도록 querydsl을 적용했습니다.

- 특정 모임 약속 목록 반환 API에서 동적으로 바뀌는 (참가자 여부에 따라, 약속 마친 여부에 따라) 부분 querydsl 적용했습니다.
- 코드도 간결해졌고, 쿼리 수도 줄었습니당
- 아직 N+1 문제는 일어나지 않지만, 이후 확장을 위해(각 promise의 참가자 데이터 사용할 시) fetchJoin 적용해주었습니다.

## Uncompleted Tasks 😅
[//]: # (없다면 N/A)
- [ ] N/A

## To Reviewers 📢
[//]: # (reviewer가 알면 좋은 내용들)